### PR TITLE
Custom traffic icons feature based on ADSB-reported aircraft and flight properties (relative altitude, vertical speed, velocity)

### DIFF
--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -1,13 +1,16 @@
 import 'dart:core';
+import 'dart:math';
+import 'dart:ui' as ui;
 import 'package:avaremp/gdl90/traffic_report_message.dart';
 import 'package:avaremp/geo_calculations.dart';
 import 'package:avaremp/storage.dart';
 import 'package:flutter/material.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:avaremp/gdl90/audible_traffic_alerts.dart';
 
 import '../gps.dart';
+
+const double _kDivBy180 = 1.0 / 180.0;
 
 class Traffic {
 
@@ -21,12 +24,14 @@ class Traffic {
   }
 
   Widget getIcon() {
-    return Transform.rotate(angle: message.heading * pi / 180,
-        child: Container(
-          decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(5),
-              color: Colors.black),
-          child:const Icon(Icons.arrow_upward_rounded, color: Colors.white,)));
+    // return Transform.rotate(angle: message.heading * pi / 180,
+    //      child: Container(
+    //        decoration: BoxDecoration(
+    //            borderRadius: BorderRadius.circular(5),
+    //            color: Colors.black),
+    //        child:const Icon(Icons.arrow_upward_rounded, color: Colors.white,)));
+    return Transform.rotate(angle: (message.heading + 180.0 /* Image painted down on coordinate plane */) * pi  * _kDivBy180,
+      child: CustomPaint(painter: _TrafficPainter(this)));
   }
 
   LatLng getCoordinates() {
@@ -39,10 +44,7 @@ class Traffic {
     "${(message.velocity * 1.94384).toInt()} knots\n"
     "${(message.verticalSpeed * 3.28).toInt()} fpm";
   }
-
 }
-
-
 
 
 class TrafficCache {
@@ -150,4 +152,221 @@ class TrafficCache {
     }
     return ret;
   }
+}
+
+enum _TrafficAircraftIconType { unmapped, light, large, rotorcraft }
+
+/// Icon painter for different traffic aircraft (ADSB emitter) types and flight status, with graduated opacity for vertically distant traffic
+class _TrafficPainter extends CustomPainter {
+
+  // Static picture cache, for faster rendering of the same image for another marker, based on flight state
+  static final Map<String,ui.Picture> _pictureCache = {};
+
+  // Const's for magic #'s and division speedup
+  static const double _kMetersToFeetCont = 3.28084;
+  static const double _kMetersPerSecondToKnots = 1.94384;
+  static const double _kDivBy60Mult = 1.0 / 60.0;
+  static const double _kDivBy1000Mult = 1.0 / 1000.0;
+  // Colors for different aircraft heights, and contrasting overlays
+  static const Color _levelColor = Color(0xFF505050);           // Level traffic = Dark grey
+  static const Color _highColor = Color(0xFF2940FF);            // High traffic = Mild dark blue
+  static const Color _lowColor = Color(0xFF50D050);             // Low traffic = Limish green
+  static const Color _groundColor = Color(0xFF836539);          // Ground traffic = Brown
+  static const Color _lightForegroundColor = Color(0xFFFFFFFF); // Overlay for darker backgrounds = White
+  static const Color _darkForegroundColor = Color(0xFF000000);  // Overlay for light backgrounds = Black
+
+  // Aircraft type outlines
+  static final ui.Path _largeAircraft = ui.Path()
+    // body
+    ..addOval(const Rect.fromLTRB(12, 5, 19, 31))
+    ..addRect(const Rect.fromLTRB(12, 11, 19, 20))..addRect(const Rect.fromLTRB(12, 11, 19, 20)) // duped, for forcing opacity
+    ..addOval(const Rect.fromLTRB(12, 0, 19, 25))..addOval(const Rect.fromLTRB(12, 0, 19, 25)) // duped, for forcing opacity
+    // left wing
+    ..addPolygon([ const Offset(0, 13), const Offset(0, 16), const Offset(15, 22), const Offset(15, 14) ], true) 
+    ..addRect(const Rect.fromLTRB(12, 14, 16, 17))  // splash of paint to cover an odd alias artifact
+    ..addPolygon([ const Offset(0, 13), const Offset(0, 16), const Offset(15, 22), const Offset(15, 14) ], true) // duped, for forcing opacity
+    // left engine
+    ..addRRect(RRect.fromRectAndRadius(const Rect.fromLTRB(6, 17, 10, 24), const Radius.circular(1)))  
+    // left h-stabilizer
+    ..addPolygon([ const Offset(9, 0), const Offset(9, 3), const Offset(15, 7), const Offset(15, 1) ], true) 
+    // right wing
+    ..addPolygon([ const Offset(31, 13), const Offset(31, 16), const Offset(17, 22), const Offset(17, 14) ], true)
+    ..addPolygon([ const Offset(31, 13), const Offset(31, 16), const Offset(17, 22), const Offset(17, 14) ], true) // duped, for forcing opacity
+    // right engine
+    ..addRRect(RRect.fromRectAndRadius(const Rect.fromLTRB(21, 17, 25, 24), const Radius.circular(1)))  
+    // right h-stabilizer
+    ..addPolygon([ const Offset(22, 0), const Offset(22, 3), const Offset(16, 7), const Offset(16, 1) ], true);       
+  static final ui.Path _defaultAircraft = ui.Path()  // default icon if no ICAO ID--just a triangle
+    ..addPolygon([ const Offset(4, 4), const Offset(15, 31), const Offset(16, 31), const Offset(27, 4), 
+      const Offset(16, 10), const Offset(15, 10) ], true);
+  static final ui.Path _lightAircraft = ui.Path()
+    ..addRRect(RRect.fromRectAndRadius(const Rect.fromLTRB(13, 18, 18, 31), const Radius.circular(2))) // body
+    ..addRRect(RRect.fromRectAndRadius(const Rect.fromLTRB(5, 19, 26, 26), const Radius.circular(1))) // wings
+    ..addRRect(RRect.fromRectAndRadius(const Rect.fromLTRB(11, 7, 20, 11), const Radius.circular(1)))  // h-stabilizer
+    ..addPolygon([ const Offset(13, 20), const Offset(15, 7), const Offset(16, 7), const Offset(18, 20)], true); // rear body
+  static final ui.Path _rotorcraft = ui.Path()
+    ..addOval(const Rect.fromLTRB(9, 11, 22, 31))
+    ..addPolygon([const Offset(29, 11), const Offset(31, 13), const Offset(2, 31), const Offset(0, 29)], true)
+    ..addPolygon([const Offset(29, 11), const Offset(31, 13), const Offset(2, 31), const Offset(0, 29)], true) // duped, for forcing opacity
+    ..addPolygon([const Offset(2, 11), const Offset(0, 13), const Offset(29, 31), const Offset(31, 29) ], true)
+    ..addPolygon([const Offset(2, 11), const Offset(0, 13), const Offset(29, 31), const Offset(31, 29) ], true) // duped, for forcing opacity
+    ..addRect(const Rect.fromLTRB(15, 0, 16, 12))
+    ..addRRect(RRect.fromLTRBR(10, 3, 21, 7, const Radius.circular(1))); //(const Rect.fromLTRB(10, 3, 21, 7));       
+  // vertical speed plus/minus overlays
+  static final ui.Path _plusSign = ui.Path()
+    ..addPolygon([ const Offset(14, 14), const Offset(14, 23), const Offset(17, 23), const Offset(17, 14) ], true)
+    ..addPolygon([ const Offset(11, 17), const Offset(20, 17), const Offset(20, 20), const Offset(11, 20) ], true)
+    ..addPolygon([ const Offset(11, 17), const Offset(20, 17), const Offset(20, 20), const Offset(11, 20) ], true);  // duped, for forcing opacity
+  static final ui.Path _minusSign = ui.Path()
+    ..addPolygon([ const Offset(11, 16), const Offset(20, 16), const Offset(20, 19), const Offset(11, 19) ], true);
+  static final ui.Path _lowerPlusSign = ui.Path()
+    ..addPolygon([ const Offset(14, 17), const Offset(14, 26), const Offset(17, 26), const Offset(17, 17) ], true)
+    ..addPolygon([ const Offset(11, 20), const Offset(20, 20), const Offset(20, 23), const Offset(11, 23) ], true)
+    ..addPolygon([ const Offset(11, 20), const Offset(20, 20), const Offset(20, 23), const Offset(11, 23) ], true);  // duped, for forcing opacity
+  static final ui.Path _lowerMinusSign = ui.Path()
+    ..addPolygon([ const Offset(11, 20), const Offset(20, 20), const Offset(20, 23), const Offset(11, 23) ], true);
+ 
+  final _TrafficAircraftIconType _aircraftType;
+  final bool _isAirborne;
+  final int _flightLevelDiff;
+  final int _vspeedDirection;
+  final int _velocityLevel;
+
+  _TrafficPainter(Traffic traffic) 
+    : _aircraftType = _getAircraftIconType(traffic.message.emitter), 
+      _isAirborne = traffic.message.airborne,
+      _flightLevelDiff = _getGrossFlightLevelDiff(traffic.message.altitude), 
+      _vspeedDirection = _getVerticalSpeedDirection(traffic.message.verticalSpeed),
+      _velocityLevel = _getVelocityLevel(traffic.message.velocity);
+
+  /// Paint arcraft, vertical speed direction overlay, and (horizontal) speed barb--using 
+  /// cached picture if possible, and drawing and caching new one for next time if not
+  @override paint(Canvas canvas, Size size) {
+    // Use pre-painted picture from cache based on relevant icon UI-driving parameters, if possible
+    final String pictureKey = "$_isAirborne^$_flightLevelDiff^$_vspeedDirection^$_velocityLevel";
+    final ui.Picture? cachedPicture = _pictureCache[pictureKey];
+    if (cachedPicture != null) {
+      canvas.drawPicture(cachedPicture);
+    } else {
+      final ui.PictureRecorder recorder = ui.PictureRecorder();
+      final ui.Canvas drawingCanvas = Canvas(recorder);
+
+      // Decide opacity, based on vertical distance from ownship and whether traffic is on the ground. 
+      // Traffic far above or below ownship will be quite transparent, to avoid clutter, and 
+      // ground traffic has a 50% max opacity / min transparency to avoid taxiing or stationary (ADSB-initilized)
+      // traffic from flooding the map. Opacity decrease is 20% for every 1000 foot diff above or below, with a 
+      // floor of 20% total opacity (i.e., max 80% transparency)
+      final double opacity = min(max(.2, (_isAirborne ? 1.0 : 0.5) - _flightLevelDiff.abs() * 0.2), (_isAirborne ? 1.0 : 0.5));
+      // Define aircraft colors using above opacity based on whether above, level, or below ownship (or on ground)
+      final Color aircraftColor;
+      if (!_isAirborne) {
+        aircraftColor = Color.fromRGBO(_groundColor.red, _groundColor.green, _groundColor.blue, opacity);
+      } else if (_flightLevelDiff > 0) {
+        aircraftColor = Color.fromRGBO(_highColor.red, _highColor.green, _highColor.blue, opacity);
+      } else if (_flightLevelDiff < 0) {
+        aircraftColor = Color.fromRGBO(_lowColor.red, _lowColor.green, _lowColor.blue, opacity);
+      } else {
+        aircraftColor = Color.fromRGBO(_levelColor.red, _levelColor.green, _levelColor.blue, opacity);
+      }
+      final Color vspeedOverlayColor;
+      if (_flightLevelDiff >= 0) {
+        vspeedOverlayColor = Color.fromRGBO(_lightForegroundColor.red, _lightForegroundColor.green, _lightForegroundColor.blue, opacity);
+      } else {
+        vspeedOverlayColor = Color.fromRGBO(_darkForegroundColor.red, _darkForegroundColor.green, _darkForegroundColor.blue, opacity);
+      }
+
+      // Set aircraft shape
+      final ui.Path baseIconShape;
+      switch(_aircraftType) {
+        case _TrafficAircraftIconType.light:
+          baseIconShape = ui.Path.from(_lightAircraft);
+          break;           
+        case _TrafficAircraftIconType.large:
+          baseIconShape = ui.Path.from(_largeAircraft);
+          break;
+        case _TrafficAircraftIconType.rotorcraft:
+          baseIconShape = ui.Path.from(_rotorcraft);
+          break;
+        default:
+          baseIconShape = ui.Path.from(_defaultAircraft);
+      }
+      
+      // Set speed barb
+      final ui.Path speedBarb = ui.Path()
+        ..addRect(Rect.fromLTWH(15, 31, 1, _velocityLevel*2.0))
+        ..addRect(Rect.fromLTWH(15, 31, 1, _velocityLevel*2.0)); // second time to prevent alias transparency interaction
+
+      // Draw aircraft and speed barb in one shot (saves rendering time/resources)
+      baseIconShape.addPath(speedBarb, const Offset(0,0));
+      drawingCanvas.drawPath(baseIconShape, Paint()..color = aircraftColor);
+
+      // draw vspeed overlay (if not level)
+      if (_vspeedDirection != 0) {
+        if (_aircraftType == _TrafficAircraftIconType.light || _aircraftType == _TrafficAircraftIconType.rotorcraft) {
+          drawingCanvas.drawPath(
+            _vspeedDirection > 0 ? _lowerPlusSign : _lowerMinusSign,
+            Paint()..color = vspeedOverlayColor
+          ); 
+        } else {
+          drawingCanvas.drawPath(
+            _vspeedDirection > 0 ? _plusSign : _minusSign,
+            Paint()..color = vspeedOverlayColor
+          );    
+        }
+      }      
+
+      // store this fresh image to the cache for next time
+      final ui.Picture newPicture = recorder.endRecording();
+      _pictureCache[pictureKey] = newPicture;
+
+      // now draw the new picture to this widget's canvas
+      canvas.drawPicture(newPicture);
+    }
+  }
+
+  // Only repaint this traffic marker if one of the flight properties affecting the icon changes
+  @override
+  bool shouldRepaint(covariant _TrafficPainter oldDelegate) {
+    return _flightLevelDiff != oldDelegate._flightLevelDiff || _velocityLevel != oldDelegate._velocityLevel 
+      ||_vspeedDirection != oldDelegate._vspeedDirection || _isAirborne != oldDelegate._isAirborne;
+  }
+
+  @pragma("vm:prefer-inline")
+  static _TrafficAircraftIconType _getAircraftIconType(int adsbEmitterCategoryId) {
+    switch(adsbEmitterCategoryId) {
+      case 1: // Light (ICAO) < 15,500 lbs 
+      case 2: // Small - 15,500 to 75,000 lbs 
+        return _TrafficAircraftIconType.light;
+      case 3: // Large - 75,000 to 300,000 lbs
+      case 4: // High Vortex Large (e.g., aircraft such as B757) 
+      case 5: // Heavy (ICAO) - > 300,000 lbs
+        return _TrafficAircraftIconType.large;
+      case 7: // Rotorcraft 
+        return _TrafficAircraftIconType.rotorcraft;
+      default:
+        return _TrafficAircraftIconType.unmapped;
+    }
+  }
+
+  /// Break flight levels into 1K chunks (bounding upper/lower to relevent opcacity limits to make image caching more efficient)
+  @pragma("vm:prefer-inline")
+  static int _getGrossFlightLevelDiff(double trafficAltitude) {
+    return max(min(((trafficAltitude - Storage().position.altitude * _kMetersToFeetCont) * _kDivBy1000Mult).round(), 5), -5);
+  }
+
+  @pragma("vm:prefer-inline")
+  static int _getVerticalSpeedDirection(double verticalSpeedMps) {
+    if (verticalSpeedMps*_kMetersToFeetCont < -100) {
+      return -1;
+    } else if (verticalSpeedMps*_kMetersToFeetCont > 100) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  @pragma("vm:prefer-inline")
+  static int _getVelocityLevel(double veloMps) {
+    return (veloMps * _kMetersPerSecondToKnots * _kDivBy60Mult).round();
+  }  
 }

--- a/lib/gdl90/traffic_report_message.dart
+++ b/lib/gdl90/traffic_report_message.dart
@@ -14,6 +14,7 @@ class TrafficReportMessage extends Message {
   double heading = 0;
   String callSign = "";
   bool airborne = false;
+  int emitter = 0;
 
   TrafficReportMessage(super.type);
 
@@ -80,6 +81,8 @@ class TrafficReportMessage extends Message {
 
     // heading / track
     heading = ((message[16].toInt() & 0xFF).toDouble() * 1.40625); // heading resolution 1.40625
+
+    emitter = message[17].toInt() & 0xFF;
 
     // call sign from 18 to 25
     Uint8List call = message.sublist(18, 26);


### PR DESCRIPTION
…nd flight properties such as relative altitude, vertical speed, and velocity/horizontal speed)

Squashed commit of the following:

commit fde7a4018b7b3f6ad4018c56949dc788a710e3b1
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 16:23:49 2024 -0500

    Much comment and naming cleanup from final review before PR

commit 7153133939232663fba8452db6ecf93cb325b6e1
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 16:20:20 2024 -0500

    Need to accept current alt (even if it looks like trash, e.g., is negative) not abs it

commit 3abbc0e2eaa369fce6b9df3a5dc4043845890da2
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 15:44:23 2024 -0500

    Snapping my latest test harness before I start PR

commit dfe5562df5cd77a43851a8b6708098b104e125cd
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 14:50:30 2024 -0500

    Minor large and light aircraft item touches

commit dfe63b2fab3e78e526ca9d52983f5787085b6427
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 11:33:23 2024 -0500

    Speed barb calculation and rendering bug fixes

commit 298657b41407c56f7126a943e8e772bd4fb0b604
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 10:33:06 2024 -0500

    Tweaked speed barb to be smaller, and did some commenting and var name refactoring

commit 664d0ae72a485d2b03e658858e9825f78971618a
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 10:32:10 2024 -0500

    Added traffic icon cache to speed rendering of identical images (massively and demonstrably increases FPS headroom and eliminates jank, according to DevTools perf monitor)

commit 4cdb83781c58566aebf4703623c21ed923a31c88
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Thu Mar 21 08:39:20 2024 -0500

    Several icon tweaks

commit 6db7f413266400b58aaf120f100f9b0eeab8d5ab
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Wed Mar 20 23:04:31 2024 -0500

    All icon paths should be static--only need to construct once

commit 805f42477f618210ea9a959452c52e5fa6b4f646
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Wed Mar 20 22:57:05 2024 -0500

    WIP with asc/desc and icon improvements

commit 23cb1cc42a1c9c238004484f3edd96681d023d44
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 15:40:16 2024 -0500

    Tweaked level (grey) aircraft color a bit more, to balance OSM and non-OSM contrast

commit 51d9a63835e20606f09dcd0dd97a30ba18062c24
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 13:19:24 2024 -0500

    Changed colors again for OSM (level was black, which was invisible) and color-blind contrast

commit e87cf51f800e800485fca604a8c72c32bab58875
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 13:02:21 2024 -0500

    Brightened blue even more for greater no-OSM (black) contrast

commit 181ea9c1b8edc59885970e521c722a394caf6545
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 12:51:43 2024 -0500

    Made blue a little lighter for when OSM is off

commit 327ed968377d5961b810c3c9365005a8e5ef22c7
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 12:30:14 2024 -0500

    More cleanup for PR and review

commit 2a5b548ca8ab690ed233929ad8a39fe68b570654
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 11:28:25 2024 -0500

    Converted a few more divisions to const multiplies (micro-opt, I know)

commit 9278afdf7b94901e47487368ecd6447fac88f241
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 10:32:20 2024 -0500

    Clean up format in preparation for PR

commit 56955ef29b19255faf3e7ebc3617c8727e1caf48
Merge: 44a4d3d 9584952
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 09:12:21 2024 -0500

    Merge branch 'traffic_icons' of github.com:shanelenagh/avaremp into traffic_icons

commit 44a4d3d1660b3d4c45fbbaa1116e587fd2d41593
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Tue Mar 19 09:10:42 2024 -0500

    Made opacity on flight levels more dramatic, removed unecessary cast on repaint check, and added more comments

commit 958495200e603ffe41a6a12beaf5286df7d38048
Author: shanelenagh <shanelenagh@users.noreply.github.com>
Date:   Mon Mar 18 21:49:51 2024 -0500

    Simplified shouldrepaint

commit eb7e117a00e7b7047fcf4aa78385d4eeadefa4d6
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Mon Mar 18 16:46:11 2024 -0500

    Added rotorcraft-specific icon

commit fcdbb49769cf4a91a4fd2e2545c94d68f9bffc1b
Merge: 93e0824 ef55e21
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Mon Mar 18 09:15:36 2024 -0500

    Merge branch 'upstream' into traffic_icons

commit 93e08246a36c864a3b074ae7ce84274fe989c211
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Mon Mar 18 08:51:11 2024 -0500

    Finished out first cut of drawn traffic icons

commit 5a78390b3ad728c5a37333e7f11136986dde9670
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Sun Mar 17 06:40:35 2024 -0500

    WIP of traffic icons

commit 17800cfa15d235d2283d9f151f8f0d700cde61e3
Author: Shane Lenagh <shanelenagh@gmail.com>
Date:   Sat Mar 16 14:29:52 2024 -0500

    Playground for new traffic icons