### PR TITLE
3 optimizations (especially eliminating double-calculation of traffic distance between traffic cache and audible alerts)

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -4,6 +4,10 @@ class Constants {
   static const bool useK = true;
   static const weatherUpdateTimeMin = 10;
 
+  static const double _kMetersToFeet = 3.28084;
+
+  @pragma("vm:prefer-inline")
+  static double mToFt(double meters) { return _kMetersToFeet * meters; }
   static double mToNm(double meters) {return 0.000539957 * meters;}
   static double nmToM(distance) {return distance / 0.000539957;}
   static String secondsToHHmm(int seconds) {

--- a/lib/gdl90/audible_traffic_alerts.dart
+++ b/lib/gdl90/audible_traffic_alerts.dart
@@ -223,29 +223,24 @@ class AudibleTrafficAlerts {
       if (traffic == null || !(traffic.message.airborne || prefIsAudibleGroundAlertsEnabled)) {
         continue;
       }
-      final double altDiff = _kMetersToFeetCont * ownshipLocation.altitude - traffic.message.altitude;
       final String trafficPositionTimeCalcUpdateValue = "${traffic.message.time.millisecondsSinceEpoch}_${ownshipUpdateTimeMs}";
       final String trafficKey = _getTrafficKey(traffic);
       final String? lastTrafficPositionUpdateValue = _lastTrafficPositionUpdateTimeMap[trafficKey];
       final bool hasUpdate;
-      double curDistance = _kMaxIntValue * 1.0;
-
       // Ensure traffic has been recently updated, and if within the alerts threshold "cylinder", upsert it to the alert queue
-      if ((hasUpdate = lastTrafficPositionUpdateValue == null || lastTrafficPositionUpdateValue != trafficPositionTimeCalcUpdateValue) &&
-          altDiff.abs() < prefTrafficAlertsHeight &&
-          (curDistance = _greatCircleDistanceNmi(ownshipLocation.latitude, ownshipLocation.longitude, traffic.message.coordinates.latitude,
-                  traffic.message.coordinates.longitude)) < prefAudibleTrafficAlertsDistanceMinimum) 
+      if ((hasUpdate = lastTrafficPositionUpdateValue == null || lastTrafficPositionUpdateValue != trafficPositionTimeCalcUpdateValue)
+          && traffic.verticalOwnshipDistanceFt.abs() < prefTrafficAlertsHeight
+          && traffic.horizontalOwnshipDistanceNmi < prefAudibleTrafficAlertsDistanceMinimum) 
       {
         hasInserts = hasInserts ||
             _upsertTrafficAlertQueue(_AlertItem(
                 traffic,
                 ownshipLocation,
-                prefIsAudibleClosingInAlerts ? _determineClosingEvent(ownshipLocation, traffic, curDistance, ownVspeed) : null,
-                curDistance,
-                altDiff));
+                prefIsAudibleClosingInAlerts ? _determineClosingEvent(ownshipLocation, traffic, ownVspeed) : null));
+          
       } else if (hasUpdate) {
         // Prune out any alert for this traffic that no longer qualifies (e.g., distance exceeded before able to process/speak)
-        _alertQueue.removeWhere((element) => element._traffic?.message.icao == traffic.message.icao);
+        _alertQueue.removeWhere((element) => element._traffic.message.icao == traffic.message.icao);
       }
       if (hasUpdate) {
         // Only update position map if there is an update
@@ -253,7 +248,8 @@ class AudibleTrafficAlerts {
       }
     }
 
-    if (hasInserts) {
+    // Only schedule a new microtask if there is a brand new alert (updates will already have one)
+    if (hasInserts) { 
       scheduleMicrotask(runAudibleAlertsQueueProcessing);
     }
   }
@@ -286,7 +282,7 @@ class AudibleTrafficAlerts {
     return false;
   }
 
-  _ClosingEvent? _determineClosingEvent(Position ownshipLocation, Traffic traffic, double currentDistance, double ownVspeed) {
+  _ClosingEvent? _determineClosingEvent(Position ownshipLocation, Traffic traffic, double ownVspeed) {
     final int ownSpeedInKts = (_kMpsToKnotsConv * ownshipLocation.speed).round();
     final double ownAltInFeet = _kMetersToFeetCont * ownshipLocation.altitude;
     final double closingEventTimeSec = (_closestApproachTime(
@@ -316,7 +312,7 @@ class AudibleTrafficAlerts {
       if (altDiff.abs() < prefClosingAlertAltitude &&
           (caDistance = _greatCircleDistanceNmi(myCaLoc.latitude, myCaLoc.longitude, theirCaLoc.latitude, theirCaLoc.longitude)) <
               prefClosestApproachThresholdNmi &&
-          currentDistance > caDistance) // catches cases when moving away
+          traffic.horizontalOwnshipDistanceNmi > caDistance) // catches cases when moving away
       {
         final bool criticallyClose = prefCriticalClosingAlertRatio > 0 &&
             (closingEventTimeSec / prefClosingTimeThresholdSeconds) <= prefCriticalClosingAlertRatio &&
@@ -376,27 +372,21 @@ class AudibleTrafficAlerts {
         _addPhoneticAlphaTrafficIdAudio(alertAudio, alert);
         break;
       case TrafficIdOption.fullCallsign:
-        _addFullCallsignTrafficIdAudio(alertAudio, alert._traffic?.message.callSign);
+        _addFullCallsignTrafficIdAudio(alertAudio, alert._traffic.message.callSign);
       default:
     }
     if (alert._closingEvent != null) {
       _addTimeToClosestPointOfApproachAudio(alertAudio, alert._closingEvent);
     }
 
-    final int clockHour = _nearestClockHourFromHeadingAndLocations(
-        alert._ownLocation?.latitude ?? 0,
-        alert._ownLocation?.longitude ?? 0,
-        alert._traffic?.message.coordinates.latitude ?? 0,
-        alert._traffic?.message.coordinates.longitude ?? 0,
-        alert._ownLocation?.heading ?? 0);
-    _addPositionAudio(alertAudio, clockHour, alert._altDiff);
+    _addPositionAudio(alertAudio, alert._clockHour, alert._traffic.verticalOwnshipDistanceFt);
 
     if (prefDistanceCalloutOption != DistanceCalloutOption.none) {
-      _addDistanceAudio(alertAudio, alert._distanceNmi);
+      _addDistanceAudio(alertAudio, alert._traffic.horizontalOwnshipDistanceNmi);
     }
 
     if (prefVerticalAttitudeCallout /* && (alert._traffic?.message.verticalSpeed??0.0 != 0.0  Indeterminate value */) {
-      _addVerticalAttitudeAudio(alertAudio, alert._traffic?.message.verticalSpeed ?? 0.0);
+      _addVerticalAttitudeAudio(alertAudio, alert._traffic.message.verticalSpeed);
     }
     return alertAudio;
   }
@@ -644,30 +634,31 @@ class _ClosingEvent {
 }
 
 class _AlertItem {
-  final Traffic? _traffic;
-  final Position? _ownLocation;
-  final double _distanceNmi;
-  final double _altDiff;
+  final Traffic _traffic;
   final _ClosingEvent? _closingEvent;
+  final int _clockHour;
 
-  _AlertItem(Traffic? traffic, Position? ownLocation, _ClosingEvent? closingEvent, double distnaceNmi, double altDiff)
+  _AlertItem(Traffic traffic, Position ownLocation, _ClosingEvent? closingEvent)
       : _traffic = traffic,
-        _ownLocation = ownLocation,
         _closingEvent = closingEvent,
-        _distanceNmi = distnaceNmi,
-        _altDiff = altDiff;
+        _clockHour = AudibleTrafficAlerts._nearestClockHourFromHeadingAndLocations(
+          ownLocation.latitude,
+          ownLocation.longitude,
+          traffic.message.coordinates.latitude,
+          traffic.message.coordinates.longitude,
+          ownLocation.heading);
 
   @override
-  int get hashCode => _traffic?.message.icao ?? 0;
+  int get hashCode => _traffic.message.icao;
 
   @override
   bool operator ==(Object other) {
-    return other is _AlertItem && other.runtimeType == runtimeType && _traffic?.message.icao == other._traffic?.message.icao;
+    return other is _AlertItem && other.runtimeType == runtimeType && _traffic.message.icao == other._traffic.message.icao;
   }
 
   @override
   String toString() {
-    return "[${AudibleTrafficAlerts._getTrafficKey(_traffic)}]: dist=${_distanceNmi}nmi, altdiff=$_altDiff, ce=[$_closingEvent]";
+    return "[${AudibleTrafficAlerts._getTrafficKey(_traffic)}]: dist=${_traffic.horizontalOwnshipDistanceNmi}nmi, altdiff=${_traffic.verticalOwnshipDistanceFt}, ce=[$_closingEvent]";
   }
 }
 

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -11,12 +11,30 @@ import 'package:avaremp/gdl90/audible_traffic_alerts.dart';
 import '../gps.dart';
 
 const double _kDivBy180 = 1.0 / 180.0;
+const double _kMetersToFeet = 3.28084;
 
 class Traffic {
 
   final TrafficReportMessage message;
+  double horizontalOwnshipDistanceNmi = 0;
+  double verticalOwnshipDistanceFt = 0;
 
-  Traffic(this.message);
+  Traffic(this.message) {
+    updateOwnshipDistances();
+  }
+
+  /// Update traffic distinces (horizontal and vertical) to ownship
+  void updateOwnshipDistances() {
+    // Use Haversine distance for speed/battery-efficiency instead of Vicenty, as the margin of error at these 
+    // distances (for these purposes) is neglible (0.3% max, within 100 miles)
+    // horizontalOwnshipDistance = GeoCalculations().calculateDistance(Gps.toLatLng(Storage().position), message.coordinates);
+    horizontalOwnshipDistanceNmi = GeoCalculations.calculateFastDistance(Gps.toLatLng(Storage().position), message.coordinates);
+    // final double vicentyDist = GeoCalculations().calculateDistance(Gps.toLatLng(Storage().position), message.coordinates);
+    // if (vicentyDist < 100 || horizontalOwnshipDistanceNmi < 100) {
+    //   print("Haversine is $horizontalOwnshipDistanceNmi and Vicenty is $vicentyDist, for a diff of ${horizontalOwnshipDistanceNmi-vicentyDist} or ${(horizontalOwnshipDistanceNmi-vicentyDist)/vicentyDist*100}%");
+    // }    
+    verticalOwnshipDistanceFt = Storage().position.altitude * _kMetersToFeet - message.altitude;
+  }
 
   bool isOld() {
     // old if more than 1 min
@@ -50,16 +68,17 @@ class Traffic {
 class TrafficCache {
   static const int maxEntries = 20;
   final List<Traffic?> _traffic = List.filled(maxEntries + 1, null); // +1 is the empty slot where new traffic is added
-
-  double findDistance(LatLng coordinate, double altitude) {
-    // find 3d distance between current position and airplane
-    // treat 1 mile of horizontal distance as 500 feet of vertical distance (C182 120kts, 1000 fpm)
-    LatLng current = Gps.toLatLng(Storage().position);
-    double horizontalDistance = GeoCalculations().calculateDistance(current, coordinate) * 500;
-    double verticalDistance   = (Storage().position.altitude * 3.28084 - altitude).abs();
-    double fac = horizontalDistance + verticalDistance;
-    return fac;
-  }
+  // Moving the raw calculation into constructor of Traffic, and the vertical distance heuristic into the sort method
+  // where it is used
+  // double findDistance(LatLng coordinate, double altitude) {
+  //   // find 3d distance between current position and airplane
+  //   // treat 1 mile of horizontal distance as 500 feet of vertical distance (C182 120kts, 1000 fpm)
+  //   LatLng current = Gps.toLatLng(Storage().position);
+  //   double horizontalDistance = GeoCalculations().calculateDistance(current, coordinate) * 500;
+  //   double verticalDistance   = (Storage().position.altitude * 3.28084 - altitude).abs();
+  //   double fac = horizontalDistance + verticalDistance;
+  //   return fac;
+  // }
 
   void putTraffic(TrafficReportMessage message) {
 
@@ -119,8 +138,10 @@ class TrafficCache {
       return 0;
     }
     if(null != left && null != right) {
-      double l = findDistance(left.message.coordinates, left.message.altitude);
-      double r = findDistance(right.message.coordinates, right.message.altitude);
+      // Use 3d distance between current position and airplane
+      // treat 1 mile of horizontal distance as 500 feet of vertical distance (C182 120kts, 1000 fpm)      
+      double l = left.horizontalOwnshipDistanceNmi * 500 + left.verticalOwnshipDistanceFt.abs();
+      double r = right.horizontalOwnshipDistanceNmi * 500 + right.verticalOwnshipDistanceFt.abs();
       if(l > r) {
         return 1;
       }
@@ -140,6 +161,16 @@ class TrafficCache {
     } else {
       AudibleTrafficAlerts.stopAudibleTrafficAlerts();
     }
+  }
+
+  /// Recalcs all traffic cache distances (e.g., from an ownship position update), then calls audible alerts
+  void updateTrafficDistancesAndAlerts() {
+    // Make async event to avoid blocking UI thread for recalcs and alerts
+    Future(() {
+      for(Traffic? t in _traffic) {
+        t?.updateOwnshipDistances;
+      }   
+    }).then((value) => handleAudibleAlerts());
   }
 
   List<Traffic> getTraffic() {

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -7,11 +7,12 @@ import 'package:avaremp/storage.dart';
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:avaremp/gdl90/audible_traffic_alerts.dart';
+import 'package:avaremp/constants.dart';
 
 import '../gps.dart';
 
 const double _kDivBy180 = 1.0 / 180.0;
-const double _kMetersToFeet = 3.28084;
+
 // Delay to allow audible alerts to not be constantly called with no updates, wasting CPU (uses async future to wait)
 const int _kAudibleAlertCallMinDelayMs = 100;
 
@@ -35,7 +36,7 @@ class Traffic {
     // if (vicentyDist < 100 || horizontalOwnshipDistanceNmi < 100) {
     //   print("Haversine is $horizontalOwnshipDistanceNmi and Vicenty is $vicentyDist, for a diff of ${horizontalOwnshipDistanceNmi-vicentyDist} or ${(horizontalOwnshipDistanceNmi-vicentyDist)/vicentyDist*100}%");
     // }    
-    verticalOwnshipDistanceFt = Storage().position.altitude * _kMetersToFeet - message.altitude;
+    verticalOwnshipDistanceFt = Constants.mToFt(Storage().position.altitude) - message.altitude;
   }
 
   bool isOld() {

--- a/lib/geo_calculations.dart
+++ b/lib/geo_calculations.dart
@@ -7,6 +7,8 @@ import 'geomag-master/lib/geomag.dart';
 class GeoCalculations {
 
   final Distance _distance = const Distance();
+  static const Distance _haversineDistance = Distance(calculator: Haversine());
+
   final GeoMag _mag = GeoMag();
 
   static const double segmentLength = 100; // nm
@@ -102,6 +104,11 @@ class GeoCalculations {
   double calculateDistance(LatLng ll1, LatLng ll2) {
     return Constants.mToNm(_distance(ll1, ll2));
   }
+
+  /// Fast distance calculation using Haversine formula (slightly < accurate, but fine for small distances, and crazy fast)
+  static double calculateFastDistance(LatLng ll1, LatLng ll2) {
+    return Constants.mToNm(_haversineDistance(ll1, ll2));
+  }  
 
   double calculateBearing(LatLng ll1, LatLng ll2) {
     double bearing = _distance.bearing(ll1, ll2);

--- a/lib/instrument_list.dart
+++ b/lib/instrument_list.dart
@@ -40,6 +40,7 @@ class InstrumentList extends StatefulWidget {
 }
 
 class InstrumentListState extends State<InstrumentList> {
+  static final DateFormat _hourMinuteFormatter = DateFormat('HH:mm');
   final List<String> _items = Storage().settings.getInstruments().split(","); // get instruments
   String _gndSpeed = "0";
   String _altitude = "0";
@@ -178,8 +179,8 @@ class InstrumentListState extends State<InstrumentList> {
       _countUp = _doCountUp ? _countUp + 1 : _countUp;
       Duration d = Duration(seconds: _countUp);
       _timerUp = _truncate(d.toString().substring(2, 7));
-      DateFormat formatter = DateFormat('HH:mm');
-      _utc = _truncate(formatter.format(DateTime.now().toUtc()));
+      
+      _utc = _truncate(_hourMinuteFormatter.format(DateTime.now().toUtc()));
       _source = Storage().gpsInternal ? "Int." : "Ext.";
     });
   }

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -228,9 +228,9 @@ class Storage {
       }
     });
     try {
-      // Have audible alerts listen for GPS changes
-      Storage().gpsChange.addListener(TrafficCache().handleAudibleAlerts);
-    } catch (e) {}
+      // Have traffic cache listen for GPS changes for distance calc and (resulting) audible alert changes
+      Storage().gpsChange.addListener(TrafficCache().updateTrafficDistancesAndAlerts);
+    } catch (e) { }
   }
 
   stopIO() {


### PR DESCRIPTION
Doing some inspection and CPU flame chart analysis of AvareX while traffic was on, I found 3 opportunities for optimization, which are addressed with this PR (the third of which doesn't deal with traffic per se, but it was something I noticed in the chart while looking at the others):

1. Traffic distance was being computed twice, once by the traffic cache in the sort method for limiting the display (and consequently audible alerts) to the "top 20" traffic items, and then again by the audible alerts itself.  I instead changed the traffic cache to do the computation once on each traffic instantiation (and then again for all traffic in the cache when ownship changes position, which would affect the prior computation for all traffic, of course), and persist that on fields on the traffic object.  That is then used by the audible alerts, which no longer needs to do it itself.  Also, as part of this, I made the algorithm for the computation use the Haversine formula (what AA was using), which is within 0.3% (3/10 of a percent) of the Vicenty formula for accuracy, but is much, much faster (CPU flame chart analysis bore this out).  And I am using the same library, LatLong, for that, as they allow you to select either Vicenty or Haversine in the constructor.  I think Vicenty makes sense in the rest of the app where high precision for less frequent calculations might be a higher concern, but when it is computing it for every traffic item often many times per second (per ADSB updates) Haversine makes more sense.
2. Changed audible alerts calls to not step on themselves.  Both the flame chart and some debugging showed the AA feature being called ridiculously frequently (every single traffic item insert) and processing every traffic item again when there were no changes.  Yes, I had code in there to exit when there was no updated timestamp, but even the multiple iterations through the cache and the hashmap check were showing up in the chart.  Now it calls the AA processing loop no more frequently than once every 100 milliseconds, which is plenty frequently still.
3. There was a dateformat that was showing up on the flame chart in the Instruments code.  I had just watched a video from the Google Flutter team on performance optimization where they used this exact thing as an example (https://youtu.be/vVg9It7cOfY?si=WcUmLXwQc66nQOM-&t=2386), so I knew the simple solution--make that format (which has no per-instance unique properties) a static of the class.  That removed it from the prominent space it was taking on the chart.

I can provide some screenshots (say of the before/after flamecharts) and screencast demo's if required; let me know.  They did have a demonstrable impact when I ran them on my device (my screaming G16 laptop with the RTX 3070 Ti didn't care, of course, but that isn't what I will be flying with :-)