### PR TITLE
Adding new Air Circular 20-172 traffic icon mode, to make icons more …

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.22.3'
+          flutter-version: '3.22.2'
 
       - name: Install project dependencies
         run: flutter pub get

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.22.2'
+          flutter-version: '3.22.3'
 
       - name: Install project dependencies
         run: flutter pub get

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -1,6 +1,3 @@
-
-import 'dart:io';
-
 import 'package:avaremp/chart.dart';
 import 'package:avaremp/documents_screen.dart';
 import 'package:avaremp/settings_cache_provider.dart';
@@ -8,10 +5,15 @@ import 'package:avaremp/settings_cache_provider.dart';
 class AppSettings {
 
   late final SettingsCacheProvider provider;
+  // local vars, to prevent constant cache lookups that are showing up in CPU flamechart
+  bool _localAudibleAlertsEnabledSetting = true;  
+  String _localUnits = "Maritime";
 
   Future<void> initSettings() async {
     provider = SettingsCacheProvider();
     provider.init();
+    _localAudibleAlertsEnabledSetting = provider.getValue("key-audible-alerts", defaultValue: _localAudibleAlertsEnabledSetting) as bool;
+    _localUnits = provider.getValue("key-units", defaultValue: _localUnits) as String;
   }
 
   void setChartType(String chart) {
@@ -72,10 +74,11 @@ class AppSettings {
 
   void setUnits(String units) {
     provider.setString("key-units", units);
+    _localUnits = units;
   }
 
   String getUnits() {
-    return provider.getValue("key-units", defaultValue: "Maritime") as String;
+    return _localUnits; // Due to number of times called, using local/memory var results in significant CPU relief
   }
 
   List<String> getLayers() {
@@ -195,11 +198,12 @@ class AppSettings {
   }
 
   bool isAudibleAlertsEnabled() { 
-    return provider.getValue("key-audible-alerts", defaultValue: true) as bool; // Windows crash issue fixed by MSIX fix
+    return _localAudibleAlertsEnabledSetting; // Due to number of times called, using local/memory var results in significant CPU relief
   }
 
   void setAudibleAlertsEnabled(bool value) {
     provider.setBool("key-audible-alerts", value);
+    _localAudibleAlertsEnabledSetting = value;
   }
 
   bool isInstrumentsVisiblePlate() {
@@ -211,4 +215,3 @@ class AppSettings {
   }
 
 }
-

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -194,9 +194,8 @@ class AppSettings {
     return provider.getValue("key-document-page-v1", defaultValue: DocumentsScreen.allDocuments) as String;
   }
 
-  bool isAudibleAlertsEnabled() {
-    bool val = provider.getValue("key-audible-alerts", defaultValue: true) as bool;
-    return Platform.isWindows ? false : val; // disable alerts for windows due to crash. XXX.
+  bool isAudibleAlertsEnabled() { 
+    return provider.getValue("key-audible-alerts", defaultValue: true) as bool; // Windows crash issue fixed by MSIX fix
   }
 
   void setAudibleAlertsEnabled(bool value) {

--- a/lib/gdl90/traffic_alerts.dart
+++ b/lib/gdl90/traffic_alerts.dart
@@ -15,6 +15,9 @@ enum DistanceCalloutOption { none, rounded, decimal }
 
 enum NumberFormatOption { colloquial, individualDigit }
 
+const _mToFt = 3.28084;
+const _mpsToKt = 1.94384;
+
 const double _deg180inv = 1.0 / 180.0;
 @pragma("vm:prefer-inline")
 double _radians(double deg) => deg * _deg180inv * pi;
@@ -24,7 +27,7 @@ const double _ln10inv = 1.0 / ln10;
 double _log10(num x) => log(x) * _ln10inv;
 
 /// Class to calculate and speak audio alerts for nearby and closing-in (TCPA) traffic
-class AudibleTrafficAlerts {
+class TrafficAlerts {
   static const double _kSecondsPerHour = 3600.000;
   static const double _kHoursPerSecond = 1.0 / 3600.000;
   static const double _kSecPerAudioSegment = 0.7; // SWAG ==> TODO: Worth putting in code to compute duration of audio-to-date exactly?
@@ -33,7 +36,7 @@ class AudibleTrafficAlerts {
   static const double _kSecPerMillseconds = 0.001;
   static const double _kHalf = 0.5;
 
-  static AudibleTrafficAlerts? _instance;
+  static TrafficAlerts? _instance;
 
   // Audio assets for each sound used to compose an alert
   final AssetSource _trafficAudio = AssetSource("tr_traffic.mp3");
@@ -121,48 +124,38 @@ class AudibleTrafficAlerts {
   final List<int> _phoneticAlphaIcaoSequenceQueue = [];
 
   // General audible alert preferences
-  bool prefIsAudibleGroundAlertsEnabled = false;
-  bool prefVerticalAttitudeCallout = false;
-  DistanceCalloutOption prefDistanceCalloutOption = DistanceCalloutOption.none;
-  NumberFormatOption prefNumberFormatOption = NumberFormatOption.colloquial;
-  TrafficIdOption prefTrafficIdOption = TrafficIdOption.none;
-  bool prefTopGunDorkMode = false;
-  int prefAudibleTrafficAlertsMinSpeed = 0;
-  int prefAudibleTrafficAlertsDistanceMinimum = 5;
-  double prefTrafficAlertsHeight = 1000;
-  int prefMaxAlertFrequencySeconds = 15;
-  int prefTimeBetweenAnyAlertMs = 750;
+  static bool prefVerticalAttitudeCallout = false;
+  static DistanceCalloutOption prefDistanceCalloutOption = DistanceCalloutOption.none;
+  static NumberFormatOption prefNumberFormatOption = NumberFormatOption.colloquial;
+  static TrafficIdOption prefTrafficIdOption = TrafficIdOption.none;
+  static bool prefTopGunDorkMode = false;
+  static int prefAudibleTrafficAlertsMinSpeed = 0;
+  static int prefAudibleTrafficAlertsDistanceMinimum = 5;
+  static double prefTrafficAlertsHeight = 1000;
+  static int prefMaxAlertFrequencySeconds = 15;
+  static int prefTimeBetweenAnyAlertMs = 750;
   // Closing (TCPA) alert preferences
-  bool prefIsAudibleClosingInAlerts = true;
-  double prefClosingAlertAltitude = 1000;
-  double prefClosingTimeThresholdSeconds = 60;
-  double prefClosestApproachThresholdNmi = 1;
-  double prefCriticalClosingAlertRatio = 0.5;
-  double _prefAudioPlayRate = 1;
-  set prefAudioPlayRate(double playRate) {
-    if (_player._audioPlayer.playbackRate != playRate) {
-      _player._audioPlayer.setPlaybackRate(playRate);
-    }
-    _prefAudioPlayRate = playRate;
-  }
-  double get prefAudioPlayRate {
-    return _prefAudioPlayRate;
-  }
+  static double prefClosingAlertAltitude = 1000;
+  static double prefClosingTimeThresholdSeconds = 60;
+  static double prefClosestApproachThresholdNmi = 1;
+  static double prefCriticalClosingAlertRatio = 0.5;
+  static double prefAudioPlayRate = 1;
 
   bool _isRunning = false;
   bool _isPlaying = false;
 
   final _AudioSequencePlayer _player = _AudioSequencePlayer("assets/audio/traffic_alerts/");
 
-  final Completer<AudibleTrafficAlerts> _startupCompleter = Completer();
+  final Completer<TrafficAlerts> _startupCompleter = Completer();
 
-  static Future<AudibleTrafficAlerts?> getAndStartAudibleTrafficAlerts() async {
+  static Future<TrafficAlerts?> getAndStartTrafficAlerts() async {
     if (_instance == null) {
-      _instance = AudibleTrafficAlerts._privateConstructor();
+      _instance = TrafficAlerts._privateConstructor();
       _instance?._loadAudio().then((value) {
         _instance?._isRunning = true;
         _instance?._startupCompleter.complete(_instance);
       });
+      _instance?._player._audioPlayer.setPlaybackRate(prefAudioPlayRate);
     }
     return _instance?._startupCompleter.future;
   }
@@ -179,7 +172,7 @@ class AudibleTrafficAlerts {
     }
   }
 
-  AudibleTrafficAlerts._privateConstructor();
+  TrafficAlerts._privateConstructor();
 
   Future<List<Uri>> _loadAudio() async {
     final List<AssetSource> audioAssets = [
@@ -209,18 +202,76 @@ class AudibleTrafficAlerts {
     return _player.preCacheAudioAssets(audioAssets);
   }
 
+  /// Encapsulate all traffic alerting calculations, setting alert level and closing/TCPA fields on traffic object
+  static void setTrafficAlertFields(Traffic? traffic, Position? ownshipPosition, bool ownIsAirborne, double ownVspeed) {
+    if (traffic == null || ownshipPosition == null) {
+      return;
+    }
+    if (!traffic.message.airborne || !ownIsAirborne) {
+      traffic.alertLevel = TrafficAlertLevel.none;
+      return;
+    }
+    if (traffic.verticalOwnshipDistanceFt.abs() < prefTrafficAlertsHeight 
+      && traffic.horizontalOwnshipDistanceNmi < prefAudibleTrafficAlertsDistanceMinimum)
+    {
+      final int ownSpeedInKts = (ownshipPosition.speed * _mpsToKt).round();
+      final double ownAltInFeet = ownshipPosition.altitude * _mToFt;
+      traffic.closingInSeconds =  (_closestApproachTime(
+                traffic.message.coordinates.latitude,
+                traffic.message.coordinates.longitude,
+                ownshipPosition.latitude,
+                ownshipPosition.longitude,
+                traffic.message.heading,
+                ownshipPosition.heading,
+                traffic.message.velocity.round(),
+                ownSpeedInKts)).abs() * _kSecondsPerHour;
+      if (traffic.closingInSeconds < prefClosingTimeThresholdSeconds) {
+        // Gate #1: Time threshold met
+        final Position myCaLoc = _locationAfterTime(ownshipPosition.latitude, ownshipPosition.longitude, ownshipPosition.heading,
+            ownSpeedInKts * 1.0, traffic.closingInSeconds * _kHoursPerSecond, ownAltInFeet, ownVspeed);
+        final Position theirCaLoc = _locationAfterTime(
+            traffic.message.coordinates.latitude,
+            traffic.message.coordinates.longitude,
+            traffic.message.heading,
+            traffic.message.velocity,
+            traffic.closingInSeconds * _kHoursPerSecond,
+            traffic.message.altitude,
+            traffic.message.verticalSpeed);
+        final double altDiff = myCaLoc.altitude - theirCaLoc.altitude;
+        // Gate #2: If traffic will be within configured "cylinder" of closing/TCPA alerts, create a closing event
+        if (altDiff.abs() < prefClosingAlertAltitude &&
+            (traffic.closestApproachDistanceNmi = _greatCircleDistanceNmi(myCaLoc.latitude, myCaLoc.longitude, theirCaLoc.latitude, theirCaLoc.longitude)) <
+                prefClosestApproachThresholdNmi &&
+            traffic.horizontalOwnshipDistanceNmi > traffic.closestApproachDistanceNmi) // catches cases when moving away
+        {
+          if (prefCriticalClosingAlertRatio > 0 &&
+              (traffic.closingInSeconds / prefClosingTimeThresholdSeconds) <= prefCriticalClosingAlertRatio &&
+              (traffic.closestApproachDistanceNmi / prefClosestApproachThresholdNmi) <= prefCriticalClosingAlertRatio) 
+          {
+            // Gate #3: Traffic will come critically close within the configured time and space parameters
+            traffic.alertLevel = TrafficAlertLevel.resolution;  
+            return;          
+          }
+        }
+      }
+      traffic.alertLevel = TrafficAlertLevel.advisory;
+      return;
+    }
+    traffic.closingInSeconds = -1;
+    traffic.alertLevel = TrafficAlertLevel.none;
+  }
+
   void processTrafficForAudibleAlerts(
       List<Traffic?> trafficList, Position? ownshipLocation, int ownshipUpdateTimeMs, double ownVspeed, bool ownIsAirborne) {
     if (!_isRunning ||
         ownshipLocation == null ||
         (Storage().units.mpsTo * ownshipLocation.speed < prefAudibleTrafficAlertsMinSpeed) ||
-        !(ownIsAirborne || prefIsAudibleGroundAlertsEnabled)) {
+        !ownIsAirborne) {
       return;
     }
-
     bool hasInserts = false;
     for (final traffic in trafficList) {
-      if (traffic == null || !(traffic.message.airborne || prefIsAudibleGroundAlertsEnabled)) {
+      if (traffic == null || !(traffic.message.airborne)) {
         continue;
       }
       final int trafficPositionTimeCalcUpdateValue = Constants.hashInts([ traffic.message.time.millisecondsSinceEpoch, ownshipUpdateTimeMs ]);
@@ -229,14 +280,18 @@ class AudibleTrafficAlerts {
       final bool hasUpdate;
       // Ensure traffic has been recently updated, and if within the alerts threshold "cylinder", upsert it to the alert queue
       if ((hasUpdate = lastTrafficPositionUpdateValue == null || lastTrafficPositionUpdateValue != trafficPositionTimeCalcUpdateValue)
-          && traffic.verticalOwnshipDistanceFt.abs() < prefTrafficAlertsHeight
-          && traffic.horizontalOwnshipDistanceNmi < prefAudibleTrafficAlertsDistanceMinimum) 
+          && (traffic.alertLevel == TrafficAlertLevel.advisory || traffic.alertLevel == TrafficAlertLevel.resolution)) 
       {
         hasInserts = hasInserts ||
-            _upsertTrafficAlertQueue(_AlertItem(
-                traffic,
-                ownshipLocation,
-                prefIsAudibleClosingInAlerts ? _determineClosingEvent(ownshipLocation, traffic, ownVspeed) : null));
+            _upsertTrafficAudibleAlertQueue(_AlertItem(traffic, ownshipLocation,
+                traffic.closingInSeconds > -1 
+                    && traffic.closingInSeconds < prefClosingTimeThresholdSeconds 
+                    && traffic.verticalOwnshipDistanceFt <= prefClosingAlertAltitude
+                    && traffic.closestApproachDistanceNmi <= prefClosestApproachThresholdNmi
+                    && traffic.closestApproachDistanceNmi < traffic.horizontalOwnshipDistanceNmi  // catches cases when moving away
+                  ? _ClosingEvent(traffic.closingInSeconds, traffic.closestApproachDistanceNmi, 
+                    traffic.alertLevel == TrafficAlertLevel.resolution) 
+                  : null));
           
       } else if (hasUpdate) {
         // Prune out any alert for this traffic that no longer qualifies (e.g., distance exceeded before able to process/speak)
@@ -254,7 +309,7 @@ class AudibleTrafficAlerts {
     }
   }
 
-  bool _upsertTrafficAlertQueue(_AlertItem alert) {
+  bool _upsertTrafficAudibleAlertQueue(_AlertItem alert) {
     final int existingIndex = _alertQueue.indexOf(alert);
     if (existingIndex == -1) {
       // If this is a "critically close" alert, put it ahead of the first non-critically close alert
@@ -280,47 +335,6 @@ class AudibleTrafficAlerts {
       _alertQueue[existingIndex] = alert;
     }
     return false;
-  }
-
-  _ClosingEvent? _determineClosingEvent(Position ownshipLocation, Traffic traffic, double ownVspeed) {
-    final int ownSpeed = (Storage().units.mpsTo * ownshipLocation.speed).round();
-    final double ownAlt = Storage().units.mToF * ownshipLocation.altitude;
-    final double closingEventTimeSec = (_closestApproachTime(
-                traffic.message.coordinates.latitude,
-                traffic.message.coordinates.longitude,
-                ownshipLocation.latitude,
-                ownshipLocation.longitude,
-                traffic.message.heading,
-                ownshipLocation.heading,
-                traffic.message.velocity.round(),
-                ownSpeed)).abs() * _kSecondsPerHour;
-    if (closingEventTimeSec < prefClosingTimeThresholdSeconds) {
-      // Gate #1: Time threshold met
-      final Position myCaLoc = _locationAfterTime(ownshipLocation.latitude, ownshipLocation.longitude, ownshipLocation.heading,
-          ownSpeed * 1.0, closingEventTimeSec * _kHoursPerSecond, ownAlt, ownVspeed);
-      final Position theirCaLoc = _locationAfterTime(
-          traffic.message.coordinates.latitude,
-          traffic.message.coordinates.longitude,
-          traffic.message.heading,
-          traffic.message.velocity,
-          closingEventTimeSec * _kHoursPerSecond,
-          traffic.message.altitude,
-          traffic.message.verticalSpeed);
-      double? caDistance;
-      final double altDiff = myCaLoc.altitude - theirCaLoc.altitude;
-      // Gate #2: If traffic will be within configured "cylinder" of closing/TCPA alerts, create a closing event
-      if (altDiff.abs() < prefClosingAlertAltitude &&
-          (caDistance = _greatCircleDistanceNmi(myCaLoc.latitude, myCaLoc.longitude, theirCaLoc.latitude, theirCaLoc.longitude)) <
-              prefClosestApproachThresholdNmi &&
-          traffic.horizontalOwnshipDistanceNmi > caDistance) // catches cases when moving away
-      {
-        final bool criticallyClose = prefCriticalClosingAlertRatio > 0 &&
-            (closingEventTimeSec / prefClosingTimeThresholdSeconds) <= prefCriticalClosingAlertRatio &&
-            (caDistance / prefClosestApproachThresholdNmi) <= prefCriticalClosingAlertRatio;
-        return _ClosingEvent(closingEventTimeSec, caDistance, criticallyClose);
-      }
-    }
-    return null;
   }
 
   void runAudibleAlertsQueueProcessing() {
@@ -627,7 +641,7 @@ class _ClosingEvent {
         _eventTimeMillis = DateTime.now().millisecondsSinceEpoch;
 
   double closingSeconds() {
-    return _closingTimeSec - (DateTime.now().millisecondsSinceEpoch - _eventTimeMillis) * AudibleTrafficAlerts._kSecPerMillseconds;
+    return _closingTimeSec - (DateTime.now().millisecondsSinceEpoch - _eventTimeMillis) * TrafficAlerts._kSecPerMillseconds;
   }
 
   @override
@@ -644,7 +658,7 @@ class _AlertItem {
   _AlertItem(Traffic traffic, Position ownLocation, _ClosingEvent? closingEvent)
       : _traffic = traffic,
         _closingEvent = closingEvent,
-        _clockHour = AudibleTrafficAlerts._nearestClockHourFromHeadingAndLocations(
+        _clockHour = TrafficAlerts._nearestClockHourFromHeadingAndLocations(
           ownLocation.latitude,
           ownLocation.longitude,
           traffic.message.coordinates.latitude,
@@ -661,7 +675,7 @@ class _AlertItem {
 
   @override
   String toString() {
-    return "[${AudibleTrafficAlerts._getTrafficKey(_traffic)}]: dist=${_traffic.horizontalOwnshipDistanceNmi}nmi, altdiff=${_traffic.verticalOwnshipDistanceFt}, ce=[$_closingEvent]";
+    return "[${TrafficAlerts._getTrafficKey(_traffic)}]: dist=${_traffic.horizontalOwnshipDistanceNmi}nmi, altdiff=${_traffic.verticalOwnshipDistanceFt}, ce=[$_closingEvent]";
   }
 }
 

--- a/lib/gdl90/traffic_alerts.dart
+++ b/lib/gdl90/traffic_alerts.dart
@@ -15,8 +15,6 @@ enum DistanceCalloutOption { none, rounded, decimal }
 
 enum NumberFormatOption { colloquial, individualDigit }
 
-const _mToFt = 3.28084;
-const _mpsToKt = 1.94384;
 
 const double _deg180inv = 1.0 / 180.0;
 @pragma("vm:prefer-inline")
@@ -214,8 +212,8 @@ class TrafficAlerts {
     if (traffic.verticalOwnshipDistanceFt.abs() < prefTrafficAlertsHeight 
       && traffic.horizontalOwnshipDistanceNmi < prefAudibleTrafficAlertsDistanceMinimum)
     {
-      final int ownSpeedInKts = (ownshipPosition.speed * _mpsToKt).round();
-      final double ownAltInFeet = ownshipPosition.altitude * _mToFt;
+      final int ownSpeedInKts = (ownshipPosition.speed * Storage().units.mpsTo).round();
+      final double ownAltInFeet = ownshipPosition.altitude * Storage().units.mToF;
       traffic.closingInSeconds =  (_closestApproachTime(
                 traffic.message.coordinates.latitude,
                 traffic.message.coordinates.longitude,

--- a/lib/gdl90/traffic_alerts.dart
+++ b/lib/gdl90/traffic_alerts.dart
@@ -285,6 +285,7 @@ class TrafficAlerts {
                 traffic.closingInSeconds > -1 
                     && traffic.closingInSeconds < prefClosingTimeThresholdSeconds 
                     && traffic.verticalOwnshipDistanceFt <= prefClosingAlertAltitude
+                    && traffic.closestApproachDistanceNmi >= 0 // not default
                     && traffic.closestApproachDistanceNmi <= prefClosestApproachThresholdNmi
                     && traffic.closestApproachDistanceNmi < traffic.horizontalOwnshipDistanceNmi  // catches cases when moving away
                   ? _ClosingEvent(traffic.closingInSeconds, traffic.closestApproachDistanceNmi, 

--- a/lib/gdl90/traffic_alerts.dart
+++ b/lib/gdl90/traffic_alerts.dart
@@ -285,7 +285,6 @@ class TrafficAlerts {
                 traffic.closingInSeconds > -1 
                     && traffic.closingInSeconds < prefClosingTimeThresholdSeconds 
                     && traffic.verticalOwnshipDistanceFt <= prefClosingAlertAltitude
-                    && traffic.closestApproachDistanceNmi >= 0 // not default
                     && traffic.closestApproachDistanceNmi <= prefClosestApproachThresholdNmi
                     && traffic.closestApproachDistanceNmi < traffic.horizontalOwnshipDistanceNmi  // catches cases when moving away
                   ? _ClosingEvent(traffic) 

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -504,8 +504,9 @@ class TrafficPainter extends AbstractCachedCustomPainter {
 
 /// Painter for traffic vertical status text box (+/- flight level, and vertical speed direction arrows)
 class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
-  static const _vertLocationTextStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w600, fontSize: 16);
-  static const _vertSpeedArrowStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w900, fontSize: 24);
+  static const double _vertLocationFontSize = 16, _vertSpeedArrowFontSize = 24;
+  static const _vertLocationTextStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w600, fontSize: _vertLocationFontSize);
+  static const _vertSpeedArrowStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w900, fontSize: _vertSpeedArrowFontSize);
   static final _boundingBoxPaint = Paint()..color = const Color.fromRGBO(0, 0, 0, .2);
   static final _leadingZeroFmt = intl.NumberFormat("00");
   static const double _offsetX = 24, _offsetY = 0;
@@ -547,7 +548,7 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
         minWidth: 0,
         maxWidth: directionText.length*_charPixeslWidth+_charPixeslWidth,
       );   
-      verticalSpeedTextPainter.paint(canvas, Offset(_offsetX+(vertLocationMsg.length*_charPixeslWidth), _offsetY-6));  
+      verticalSpeedTextPainter.paint(canvas, Offset(_offsetX+(vertLocationMsg.length*_charPixeslWidth), _offsetY-(_vertSpeedArrowFontSize-_vertLocationFontSize)));  
     }
 
   }

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -504,10 +504,12 @@ class TrafficPainter extends AbstractCachedCustomPainter {
 
 /// Painter for traffic vertical status text box (+/- flight level, and vertical speed direction arrows)
 class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
-  static const _statusTextStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w600, fontSize: 16);
+  static const _vertLocationTextStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w600, fontSize: 16);
+  static const _vertSpeedArrowStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Constants.instrumentsNormalLabelColor, fontWeight: FontWeight.w900, fontSize: 24);
   static final _boundingBoxPaint = Paint()..color = const Color.fromRGBO(0, 0, 0, .2);
   static final _leadingZeroFmt = intl.NumberFormat("00");
   static const double _offsetX = 24, _offsetY = 0;
+  static const double _charPixeslWidth = 10;
 
   final int _flightLevelDiff;
   final int _vspeedDirection;
@@ -526,19 +528,28 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
       return;
     }
     
-    final String statusMsg = (_flightLevelDiff > 0 ? "+" : "") + _leadingZeroFmt.format(_flightLevelDiff)
-        + (_vspeedDirection > 0 ? "⇑" : (_vspeedDirection < 0 ? "⇓": ""));
+    final String vertLocationMsg = (_flightLevelDiff > 0 ? "+" : "") + _leadingZeroFmt.format(_flightLevelDiff);
+    final String directionText = (_vspeedDirection > 0 ? "↑" : (_vspeedDirection < 0 ? "↓": ""));
     // Draw transluscent bounding box for greater visibility (especially sectionals)
     final ui.Path statusBoundingBox = ui.Path()
-      ..addRect(Rect.fromLTRB(_offsetX, _offsetY, _offsetX+statusMsg.length*11, _offsetY+24)); 
+      ..addRect(Rect.fromLTRB(_offsetX, _offsetY, _offsetX+(vertLocationMsg.length+directionText.length)*_charPixeslWidth+_charPixeslWidth, _offsetY+24)); 
     canvas.drawPath(statusBoundingBox, _boundingBoxPaint);   
     // Paint vertical position  
-    final textPainter = TextPainter(text: TextSpan(text: statusMsg, style: _statusTextStyle), textDirection: TextDirection.ltr);
-    textPainter.layout(
+    final vertLocationTextPainter = TextPainter(text: TextSpan(text: vertLocationMsg, style: _vertLocationTextStyle), textDirection: TextDirection.ltr);
+    vertLocationTextPainter.layout(
       minWidth: 0,
-      maxWidth: 200,
+      maxWidth: vertLocationMsg.length*_charPixeslWidth,
     );    
-    textPainter.paint(canvas, const Offset(_offsetX, _offsetY));
+    vertLocationTextPainter.paint(canvas, const Offset(_offsetX, _offsetY));
+    if (directionText.isNotEmpty) {
+      final verticalSpeedTextPainter = TextPainter(text: TextSpan(text: directionText, style: _vertSpeedArrowStyle), textDirection: TextDirection.ltr);
+      verticalSpeedTextPainter.layout(
+        minWidth: 0,
+        maxWidth: directionText.length*_charPixeslWidth+_charPixeslWidth,
+      );   
+      verticalSpeedTextPainter.paint(canvas, Offset(_offsetX+(vertLocationMsg.length*_charPixeslWidth), _offsetY-6));  
+    }
+
   }
 
   /// get flight level

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -241,12 +241,12 @@ enum _TrafficAircraftIconType { unmapped, light, large, rotorcraft }
 class TrafficPainter extends AbstractCachedCustomPainter {
 
   // Preference control variables
-  static bool prefShowSpeedBarb = false;                    // Shows line/barb at tip of icon based on speed/velocity
-  static bool prefAltDiffOpacityGraduation = false;         // Gradually vary opacity of icon based on altitude diff from ownship
-  static bool prefUseDifferentDefaultIconThanLight = false; // Use a different default icon for unmapped or "0" emitter category ID traffic
-  static bool prefShowBoundingBox = false;                  // Display outlined bounding box around icon for higher visibility
-  static bool prefShowShadow = false;                       // Display shadow effect "under" aircraft for higher visibility
-  static bool prefShowShapeOutline = true;                  // Display solid outline around aircraft for higher visibility
+  static const bool prefShowSpeedBarb = false;                    // Shows line/barb at tip of icon based on speed/velocity
+  static const bool prefAltDiffOpacityGraduation = false;         // Gradually vary opacity of icon based on altitude diff from ownship
+  static const bool prefUseDifferentDefaultIconThanLight = false; // Use a different default icon for unmapped or "0" emitter category ID traffic
+  static const bool prefShowBoundingBox = false;                  // Display outlined bounding box around icon for higher visibility
+  static const bool prefShowShadow = false;                       // Display shadow effect "under" aircraft for higher visibility
+  static const bool prefShowShapeOutline = true;                  // Display solid outline around aircraft for higher visibility
 
   // Const's for magic #'s and division speedup
   static final double _kMetersToFeetCont = Storage().units.mToF;
@@ -339,12 +339,12 @@ class TrafficPainter extends AbstractCachedCustomPainter {
   TrafficPainter(Traffic traffic) 
     : _aircraftType = _getAircraftIconType(traffic.message.emitter), 
       _isAirborne = traffic.message.airborne,
-      _flightLevelDiff = _getGrossFlightLevelDiff(traffic), 
-      _vspeedDirection = getVerticalSpeedDirection(traffic.message.verticalSpeed),
+      _flightLevelDiff = prefAltDiffOpacityGraduation || !TrafficCache.ac20_172Mode ? _getGrossFlightLevelDiff(traffic) : 0, 
+      _vspeedDirection = !TrafficCache.ac20_172Mode ? getVerticalSpeedDirection(traffic.message.verticalSpeed) : 0,
       _velocityLevel = prefShowSpeedBarb ? _getVelocityLevel(traffic.message.velocity) : 0,
       _alertLevel = traffic.alertLevel,
       super([ _getAircraftIconType(traffic.message.emitter).index, traffic.message.airborne ? 1 : 0, 
-        prefAltDiffOpacityGraduation ? _getGrossFlightLevelDiff(traffic) : 0, // no variation on alt diff if no opacity gradation
+        prefAltDiffOpacityGraduation || !TrafficCache.ac20_172Mode ? _getGrossFlightLevelDiff(traffic) : 0, // no variation on alt diff if no opacity gradation or in AC 20-172 mode
         !TrafficCache.ac20_172Mode ? getVerticalSpeedDirection(traffic.message.verticalSpeed) : 0, // No variation for +/- overlay if AC 20-172 mode 
         prefShowSpeedBarb ? _getVelocityLevel(traffic.message.velocity) : 0, traffic.alertLevel.index ], prefShowShadow, const Size(32, 32));
 

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -78,7 +78,7 @@ class Traffic {
   @override
   String toString() {
     return "${message.callSign}\n${message.altitude.toInt()} ft\n"
-    "${(message.velocity * Storage().units.mpsTo).toInt()} knots\n"
+    "${(message.velocity * Storage().units.mpsTo).toInt()} ${Storage().settings.getUnits() == "Imperial" ? "mph" : "knots" }\n"
     "${(message.verticalSpeed * Storage().units.mToF).toInt()} fpm";
   }
 }

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -543,6 +543,7 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
       maxWidth: vertLocationMsg.length*_charPixeslWidth,
     );    
     vertLocationTextPainter.paint(canvas, const Offset(_offsetX, _offsetY));
+    // Paint ascending/descending direction arrows (if not flying level)
     if (directionText.isNotEmpty) {
       final verticalSpeedTextPainter = TextPainter(text: TextSpan(text: directionText, style: _vertSpeedArrowStyle), textDirection: TextDirection.ltr);
       verticalSpeedTextPainter.layout(
@@ -551,7 +552,6 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
       );   
       verticalSpeedTextPainter.paint(canvas, Offset(_offsetX+(vertLocationMsg.length*_charPixeslWidth), _offsetY-(_vertSpeedArrowFontSize-_vertLocationFontSize)));  
     }
-
   }
 
   /// get flight level
@@ -563,7 +563,7 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
 
 /// Paints an AC 20-172 alert overlay (orange circle for nearby alert, red box for critical resolution alert)
 class AlertBoxPainter extends AbstractCachedCustomPainter {
-  static const _alertRect = Rect.fromLTRB(-10, -10, 50, 50);
+  static const _alertRect = Rect.fromLTRB(-15, -15, 45, 45);
   static final _alertCircle = ui.Path()..addOval(_alertRect);
   static final _resolutionBox = ui.Path()..addRect(_alertRect);
   static final Paint _outlinePaint = Paint()
@@ -659,7 +659,7 @@ abstract class AbstractCachedCustomPainter extends CustomPainter {
     canvas.drawPicture(picture);
   }
 
-  /// Hook for implementing painter to paint their icon UI
+  /// Abstract hook for implementing painter to paint the custom UI
   void freshPaint(ui.Canvas canvas);
 
   @override

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -527,7 +527,7 @@ class TrafficVerticalStatusPainter extends AbstractCachedCustomPainter {
     }
     
     final String statusMsg = (_flightLevelDiff > 0 ? "+" : "") + _leadingZeroFmt.format(_flightLevelDiff)
-        + (_vspeedDirection > 0 ? "🠉" : (_vspeedDirection < 0 ? "🠋": ""));
+        + (_vspeedDirection > 0 ? "⇑" : (_vspeedDirection < 0 ? "⇓": ""));
     // Draw transluscent bounding box for greater visibility (especially sectionals)
     final ui.Path statusBoundingBox = ui.Path()
       ..addRect(Rect.fromLTRB(_offsetX, _offsetY, _offsetX+statusMsg.length*11, _offsetY+24)); 

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -343,9 +343,10 @@ class TrafficPainter extends AbstractCachedCustomPainter {
       _vspeedDirection = getVerticalSpeedDirection(traffic.message.verticalSpeed),
       _velocityLevel = prefShowSpeedBarb ? _getVelocityLevel(traffic.message.velocity) : 0,
       _alertLevel = traffic.alertLevel,
-      super([ _getAircraftIconType(traffic.message.emitter).index, traffic.message.airborne ? 1 : 0, _getGrossFlightLevelDiff(traffic),
-        getVerticalSpeedDirection(traffic.message.verticalSpeed), prefShowSpeedBarb ? _getVelocityLevel(traffic.message.velocity) : 0,
-        traffic.alertLevel.index ], prefShowShadow, const Size(32, 32));
+      super([ _getAircraftIconType(traffic.message.emitter).index, traffic.message.airborne ? 1 : 0, 
+        prefAltDiffOpacityGraduation ? _getGrossFlightLevelDiff(traffic) : 0, // no variation on alt diff if no opacity gradation
+        !TrafficCache.ac20_172Mode ? getVerticalSpeedDirection(traffic.message.verticalSpeed) : 0, // No variation for +/- overlay if AC 20-172 mode 
+        prefShowSpeedBarb ? _getVelocityLevel(traffic.message.velocity) : 0, traffic.alertLevel.index ], prefShowShadow, const Size(32, 32));
 
   /// Paint arcraft, vertical speed direction overlay, and optionially (horizontal) speed barb
   @override 

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -27,7 +27,7 @@ class Traffic {
   double horizontalOwnshipDistanceNmi = 0;
   double verticalOwnshipDistanceFt = 0;
   double closingInSeconds = -1;
-  double closestApproachDistanceNmi = -1;
+  double closestApproachDistanceNmi = 999999;
   TrafficAlertLevel alertLevel = TrafficAlertLevel.none;
 
   Traffic(this.message) {

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -535,9 +535,7 @@ class MapScreenState extends State<MapScreen> {
                       content: Container(padding: const EdgeInsets.all(5), child:Text(e.toString())),
                       triggerMode: TooltipTriggerMode.tap,
                       waitDuration: const Duration(seconds: 1),
-                      child: Transform.rotate(angle: _northUp ? 0 : -Storage().position.heading * pi / 180,
-                        child: e.getIcon()
-                      )
+                      child: e.getIcon(_northUp, Storage().settings.isAudibleAlertsEnabled())
                     )
                   ),
                   onLongPress: () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,11 @@ dependencies:
   dio_cache_interceptor_file_store: ^1.2.3
   point_in_polygon: ^1.0.0
   toastification: ^2.0.0
+  # 2024-07-20 Shane Lenagh: Old MSVC library crash issue workaround (for audioplayers in audible alerts): https://github.com/YehudaKremer/msix/issues/272#issuecomment-2181634105
+  msvcredist:
+    git:
+      url: https://github.com/insertjokehere/flutter_msvcredist.git
+      ref: main   
 
 flutter_launcher_icons:
   android: "launcher_icon"
@@ -111,7 +116,12 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^3.0.1
   build_runner: ^2.4.8
-  msix: ^3.16.7
+  # 2024-07-20 Shane Lenagh: Old MSVC library crash issue workaround (for audioplayers in audible alerts): https://github.com/YehudaKremer/msix/issues/272#issuecomment-2181634105
+  #msix: ^3.16.7
+  msix:
+    git:
+      url: https://github.com/insertjokehere/msix.git
+      ref: msvc_redist 
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
…visible and consistent with the ADSB/TCAS standards.  This PR includes the following items:

1. New AC 20-172 icons, nominally cyan triangles with a solid black outline.  When traffic gets closer the color changes, and overlays appear with an orange circle "advisory" (very close traffic) status and  a red square for "resolution" (closing with a time of closest point of approach within a critical range) status.
2. The relative flight level and ascending/descending status are indicated by a box to the right of the traffic icon showing the relative flight level in hundreds of feet, similar to classic Avare, with and up (🠉) or down (🠋) arrow if the traffic is ascending or descending.
3. Fixed the Windows crash of the audible alerts by implementing a workaround fix (until they fix the mainline package) for the MSIX package, per this issue report: https://github.com/YehudaKremer/msix/issues/272#issuecomment-2181634105
4. Made the audible alerts muted icon the standard Material "volume off" icon we previously discussed, in a semi-transparent white paint (clutters the UI less and has clearer intent than the black X, IMHO).  Let me know what you think.

I am sending you a video walkthrough of the code and features.  Sorry it took so long to do this.