### PR TITLE
Remove trailing empty lines on checklist import

### DIFF
--- a/lib/checklist_screen.dart
+++ b/lib/checklist_screen.dart
@@ -51,9 +51,9 @@ class ChecklistScreenState extends State<ChecklistScreen> {
           }
           String name = lines.removeAt(0);
           //remove trailing empty lines
-          while(!lines.isEmpty)
+          while(lines.isNotEmpty)
           {
-            if(lines[lines.length - 1].length == 0) {
+            if(lines[lines.length - 1].isEmpty) {
                 lines.removeAt(lines.length - 1);
             }
             else {

--- a/lib/checklist_screen.dart
+++ b/lib/checklist_screen.dart
@@ -52,10 +52,10 @@ class ChecklistScreenState extends State<ChecklistScreen> {
           String name = lines.removeAt(0);
           //remove trailing empty lines, back to front, until no lines remain or
           //first nonnull line is found
-          while(lines.isNotEmpty)
+          for(int i = lines.length - 1; i >= 0; i--)
           {
-            if(lines[lines.length - 1].isEmpty) {
-                lines.removeAt(lines.length - 1);
+            if(lines[i].isEmpty) {
+                lines.removeLast();
             }
             else {
                 break;

--- a/lib/checklist_screen.dart
+++ b/lib/checklist_screen.dart
@@ -50,6 +50,12 @@ class ChecklistScreenState extends State<ChecklistScreen> {
             return;
           }
           String name = lines.removeAt(0);
+          //remove leading empty lines until no lines remain or
+          //first nonnull line is found
+          while(lines.isNotEmpty && lines[0].isEmpty)
+          {
+              lines.removeAt(0);
+          }
           //remove trailing empty lines, back to front, until no lines remain or
           //first nonnull line is found
           for(int i = lines.length - 1; i >= 0; i--)

--- a/lib/checklist_screen.dart
+++ b/lib/checklist_screen.dart
@@ -50,7 +50,8 @@ class ChecklistScreenState extends State<ChecklistScreen> {
             return;
           }
           String name = lines.removeAt(0);
-          //remove trailing empty lines
+          //remove trailing empty lines, back to front, until no lines remain or
+          //first nonnull line is found
           while(lines.isNotEmpty)
           {
             if(lines[lines.length - 1].isEmpty) {

--- a/lib/checklist_screen.dart
+++ b/lib/checklist_screen.dart
@@ -50,6 +50,16 @@ class ChecklistScreenState extends State<ChecklistScreen> {
             return;
           }
           String name = lines.removeAt(0);
+          //remove trailing empty lines
+          while(!lines.isEmpty)
+          {
+            if(lines[lines.length - 1].length == 0) {
+                lines.removeAt(lines.length - 1);
+            }
+            else {
+                break;
+            }
+          }
           Checklist list = Checklist(name, "", lines);
           Storage().realmHelper.addChecklist(list);
         }));},


### PR DESCRIPTION
Resolves a minor oversight I found where upon importation of a checklist, trailing empty lines will get their own checklist entry. This change removes those empty trailing entries during the loading process.

I decided not to remove empty lines surrounded by text, since those could have some use as a spacer. (It may be worth keeping the spaces they create while removing their corresponding checkbox)

![Screenshot from 2024-09-07 23-47-17](https://github.com/user-attachments/assets/e23eb19a-e69a-4cbe-9080-728e7afac507)
