### PR TITLE
Add water runway identifier to airport heading regex

### DIFF
--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -138,7 +138,7 @@ class Airport {
       catch (e) {
         try {
           headingL =
-              double.parse(r['LEIdent'].replaceAll(RegExp(r'[LCR]'), '')) * 10 - geo.getVariation(LatLng(lat, lon)); // remove L, R, C from it
+              double.parse(r['LEIdent'].replaceAll(RegExp(r'[LCRW]'), '')) * 10 - geo.getVariation(LatLng(lat, lon)); // remove L, R, C, W from it
         }
         catch (e) {
           continue; // give up, as we tried everything possible to find a runway


### PR DESCRIPTION
Adds the "W" runway identifier to allow the heading parser to parse water runways, as it already does for the letters appended to runway headings for left/center/right runways. 

e.g. PAJN/JNU has runways 8W/26W.