### PR TITLE
Improve airport diagram rendering

### DIFF
--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -315,9 +315,30 @@ class RunwayPainter extends CustomPainter {
         double hy = (top - heLat) * py;
 
         // draws the runway
+        String surf = r['Surface'];
+        Color surfcolor = Colors.grey;
+
+        if(surf == 'WATER') {
+          surfcolor = Colors.blue;
+        }
+        else {
+          switch(surf.substring(0,4)) {
+            case 'ASPH':
+              surfcolor = Colors.grey.shade700;
+            case 'CONC':
+              surfcolor = Colors.grey;
+            case 'TURF':
+              surfcolor = Colors.green;
+            case 'DIRT':
+              surfcolor = Colors.brown;
+            case 'SAND':
+              surfcolor = Colors.amber.shade200;
+          }
+        }
+
         final paintLine = Paint()
           ..strokeWidth = width
-          ..color = Colors.green.withOpacity(0.8); // runway color
+          ..color = surfcolor.withOpacity(0.8);
 
         double offsetX = 0;
         double offsetY = 0;

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -272,6 +272,7 @@ class RunwayPainter extends CustomPainter {
 
     String info = "";
 
+    //for each runway at this airport, draw the physical shape and then the data for each runway identifier
     for(Map<String, dynamic> r in runways) {
 
       double width = 0; // draw runways to width
@@ -313,6 +314,7 @@ class RunwayPainter extends CustomPainter {
         double hx = (left - heLon) * px;
         double hy = (top - heLat) * py;
 
+        // draws the runway
         final paintLine = Paint()
           ..strokeWidth = width
           ..color = Colors.green.withOpacity(0.8); // runway color
@@ -322,6 +324,7 @@ class RunwayPainter extends CustomPainter {
 
         canvas.drawLine(Offset(lx + offsetX, ly + offsetY), Offset(hx + offsetX, hy + offsetY), paintLine);
 
+        //create info string for low end runway identifier (1-17)
         String ident = "${r['LEIdent']} ";
         String pattern = r['LEPattern'] == 'Y' ? 'RP ' : '';
         String lights = r['LELights'].isEmpty ? "" : "${r['LELights']} ";
@@ -334,6 +337,7 @@ class RunwayPainter extends CustomPainter {
 
         info += "$ident$pattern$lights$ils$vgsi\n";
 
+        //create info string for high end runway identifier (18...36)
         ident = "${r['HEIdent']} ";
         pattern = r['HEPattern'] == 'Y' ? 'RP ' : '';
         lights = r['HELights'].isEmpty ? "" : "${r['HELights']} ";
@@ -359,7 +363,4 @@ class RunwayPainter extends CustomPainter {
   bool shouldRepaint(covariant CustomPainter oldDelegate) {
   return false;
   }
-
-
-
 }

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -272,7 +272,15 @@ class RunwayPainter extends CustomPainter {
 
     String info = "";
 
+    double apLat = airport.coordinate.latitude;
+    double apLon = airport.coordinate.longitude;
+
+    String hemisphereLat = apLat > 0 ? 'N' : 'S';
+    String hemisphereLon = apLon > 0 ? 'E' : 'W';
+
     info += '${airport.facilityName} (${airport})\n';
+    info += 'ELEV ${airport.elevation}\'\n';
+    info += '${apLat.abs().toStringAsPrecision(5)}°${hemisphereLat} ${apLon.abs().toStringAsPrecision(5)}°${hemisphereLon}\n\n';
 
     //for each runway at this airport, draw the physical shape and then the data for each runway identifier
     for(Map<String, dynamic> r in runways) {
@@ -352,9 +360,6 @@ class RunwayPainter extends CustomPainter {
         if(r['Length'] == "0") { // odd stuff like 0 length runways
           continue;
         }
-
-        double apLat = airport.coordinate.latitude;
-        double apLon = airport.coordinate.longitude;
 
         // adding this factor should cover all airport in US from center of the airport.
         double left = apLon - avg;

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -343,11 +343,11 @@ class RunwayPainter extends CustomPainter {
         double offsetX = 0;
         double offsetY = 0;
 
+        canvas.drawLine(Offset(lx + offsetX, ly + offsetY), Offset(hx + offsetX, hy + offsetY), paintLine);
+
         //calculate actual runway identifier headings
         double heHeading = pi/2 - atan2((leLat-heLat),(leLon-heLon));
         double leHeading = heHeading - pi;
-
-        canvas.drawLine(Offset(lx + offsetX, ly + offsetY), Offset(hx + offsetX, hy + offsetY), paintLine);
 
         //create info string for low end runway identifier (1-17)
         String ident = "${r['LEIdent']} ";
@@ -379,7 +379,17 @@ class RunwayPainter extends CustomPainter {
         canvas.translate(hx + offsetX, hy + offsetY);
         canvas.rotate(heHeading);
         tp.paint(canvas, Offset(-(tp.width / 2),0));
+
+        //runway length text
+        canvas.rotate(pi/2); //rotate 90 degrees for runway length text
+        canvas.translate(-sqrt(pow(ly-hy, 2) + pow(lx-hx, 2))/2, 0); //move canvas to center of runway
+        String dimensions = "${r['Length']}x${r['Width']}\n";
+        span = TextSpan(style: TextStyle(color: Theme.of(context).colorScheme.primary, fontSize: scale / 96), text: dimensions);
+        tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
+        tp.layout();
+        tp.paint(canvas, Offset(-tp.width/2,(-width-tp.height) / 2));
         canvas.restore();
+
         info += "$ident$pattern$lights$ils$vgsi\n";
         info += "  ${r['Length']}x${r['Width']} ${r['Surface']}\n\n";
       }
@@ -388,7 +398,7 @@ class RunwayPainter extends CustomPainter {
     TextSpan span = TextSpan(style: TextStyle(color: Theme.of(context).colorScheme.primary, fontSize: scale / 64), text: info);
     TextPainter tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
     tp.layout();
-    tp.paint(canvas, Offset(10, scale.toInt() / 4))  ;
+    tp.paint(canvas, Offset(10, scale.toInt() / 4));
   }
 
   @override

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -503,10 +503,7 @@ class RunwayPainter extends CustomPainter {
 
         //create info string for high end runway identifier (18...36)
         ident = "${r['HEIdent']} ";
-        pattern = r['HEPattern'] == 'Y' ? 'RP ' : '';
-        lights = r['HELights'].isEmpty ? "" : "${r['HELights']} ";
-        ils = r['HEILS'].isEmpty ? "" : "${r['HEILS']} ";
-        vgsi = r['HEVGSI'].isEmpty ? "" : "${r['HEVGSI']} ";
+
         span = TextSpan(style: TextStyle(color: Theme.of(context).colorScheme.primary, fontSize: scale / 64), text: ident);
         tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
         tp.layout();
@@ -526,6 +523,11 @@ class RunwayPainter extends CustomPainter {
         tp.layout();
         tp.paint(canvas, Offset(-tp.width/2,(-width-tp.height) / 2));
         canvas.restore();
+
+        pattern = r['HEPattern'] == 'Y' ? 'RP ' : '';
+        lights = r['HELights'].isEmpty ? "" : "${r['HELights']} ";
+        ils = r['HEILS'].isEmpty ? "" : "${r['HEILS']} ";
+        vgsi = r['HEVGSI'].isEmpty ? "" : "${r['HEVGSI']} ";
 
         info += "$ident$pattern$lights$ils$vgsi\n";
         info += "  ${r['Length']}x${r['Width']} ${r['Surface']}\n\n";

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -272,6 +272,8 @@ class RunwayPainter extends CustomPainter {
 
     String info = "";
 
+    info += '${airport.facilityName} (${airport})\n';
+
     //for each runway at this airport, draw the physical shape and then the data for each runway identifier
     for(Map<String, dynamic> r in runways) {
 

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -322,6 +322,10 @@ class RunwayPainter extends CustomPainter {
         double offsetX = 0;
         double offsetY = 0;
 
+        //calculate actual runway identifier headings
+        double heHeading = pi/2 - atan2((leLat-heLat),(leLon-heLon));
+        double leHeading = heHeading - pi;
+
         canvas.drawLine(Offset(lx + offsetX, ly + offsetY), Offset(hx + offsetX, hy + offsetY), paintLine);
 
         //create info string for low end runway identifier (1-17)
@@ -333,7 +337,11 @@ class RunwayPainter extends CustomPainter {
         TextSpan span = TextSpan(style: TextStyle(color: Theme.of(context).colorScheme.primary, fontSize: scale / 64), text: ident);
         TextPainter tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
         tp.layout();
-        tp.paint(canvas, Offset(lx + offsetX, ly + offsetY));
+        canvas.save();
+        canvas.translate(lx + offsetX, ly + offsetY);
+        canvas.rotate(leHeading);
+        tp.paint(canvas, Offset(-(tp.width / 2),0));
+        canvas.restore();
 
         info += "$ident$pattern$lights$ils$vgsi\n";
 
@@ -346,8 +354,11 @@ class RunwayPainter extends CustomPainter {
         span = TextSpan(style: TextStyle(color: Theme.of(context).colorScheme.primary, fontSize: scale / 64), text: ident);
         tp = TextPainter(text: span, textAlign: TextAlign.left, textDirection: TextDirection.ltr);
         tp.layout();
-        tp.paint(canvas, Offset(hx + offsetX, hy + offsetY));
-
+        canvas.save();
+        canvas.translate(hx + offsetX, hy + offsetY);
+        canvas.rotate(heHeading);
+        tp.paint(canvas, Offset(-(tp.width / 2),0));
+        canvas.restore();
         info += "$ident$pattern$lights$ils$vgsi\n";
         info += "  ${r['Length']}x${r['Width']} ${r['Surface']}\n\n";
       }

--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -271,6 +271,37 @@ class RunwayPainter extends CustomPainter {
     return runwayNumber * 10;
   }
 
+  //Attempts to query the appropriate runway color for the given runway object.
+  //Returns grey if no surface is defined.
+  static Color runwayColorFromSurface(Map<String, dynamic> r)
+  {
+    Color surfcolor = Colors.grey;
+    try {
+      String surf = r['Surface'];
+
+      if(surf == 'WATER') {
+        surfcolor = Colors.blue;
+      }
+      else {
+        switch(surf.substring(0,4)) {
+          case 'ASPH':
+            surfcolor = Colors.grey.shade700;
+          case 'CONC':
+            surfcolor = Colors.grey;
+          case 'TURF':
+            surfcolor = Colors.green;
+          case 'DIRT':
+            surfcolor = Colors.brown;
+          case 'SAND':
+            surfcolor = Colors.amber.shade200;
+        }
+      }
+    }
+    catch (e) {
+    }
+    return surfcolor;
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
 
@@ -397,32 +428,7 @@ class RunwayPainter extends CustomPainter {
           continue;
         }
 
-        // draws the runway
-        Color surfcolor = Colors.grey;
-        try {
-          String surf = r['Surface'];
-
-          if(surf == 'WATER') {
-            surfcolor = Colors.blue;
-          }
-          else {
-            switch(surf.substring(0,4)) {
-              case 'ASPH':
-                surfcolor = Colors.grey.shade700;
-              case 'CONC':
-                surfcolor = Colors.grey;
-              case 'TURF':
-                surfcolor = Colors.green;
-              case 'DIRT':
-                surfcolor = Colors.brown;
-              case 'SAND':
-                surfcolor = Colors.amber.shade200;
-            }
-          }
-        }
-        catch (e) {
-        }
-
+        Color surfcolor = runwayColorFromSurface(r);
         final paintLine = Paint()
           ..strokeWidth = width
           ..color = surfcolor.withOpacity(0.8);


### PR DESCRIPTION
- Centers and orients runway identifiers normal to their respective runways, in the airport diagram screen.
- Prints runways in colors corresponding to surface type (asphalt, concrete, turf, gravel, dirt, sand, water)
- Prints runway dimensions alongside their respective runways, in addition to the information tabulated on the left hand side
- Prints airport name, identifier, elevation, and coordinates
- Generates approximate coordinates for single-runway airports with no runway end coordinates (from length & runway ident)

 Formatting and color selection feedback welcome, they have been picked somewhat arbitrarily.
 
Before:

PDX
![Screenshot from 2024-11-05 12-18-11](https://github.com/user-attachments/assets/9b6c5570-98fc-4f0e-a86b-5a2c5f1be607)

APF
![Screenshot from 2024-11-05 12-12-14](https://github.com/user-attachments/assets/b6970e41-40a2-4036-bd25-5549ef0656ba)


After:

![Screenshot from 2024-11-12 17-57-56](https://github.com/user-attachments/assets/d0f430c7-fb6a-47f6-a9bd-84cd051ab441)
![Screenshot from 2024-11-13 22-04-49](https://github.com/user-attachments/assets/3a7a1a21-4410-472a-8d6e-ab04f33cd495)
![Screenshot from 2024-11-13 22-04-29](https://github.com/user-attachments/assets/7754871b-eca1-4475-b1d7-fffaecc534d2)
(19WA has no runway end coordinates, previously nothing would be rendered here)
![Screenshot from 2024-11-13 00-10-05](https://github.com/user-attachments/assets/997191a0-e0b7-4f04-8c97-3c7b194b1e4e)

