### PR TITLE
Ignore condition information for water runways

### DIFF
--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -279,7 +279,7 @@ class RunwayPainter extends CustomPainter {
     try {
       String surf = r['Surface'];
 
-      if(surf == 'WATER') {
+      if(surf.substring(0,5) == 'WATER') {
         surfcolor = Colors.blue;
       }
       else {


### PR DESCRIPTION
Fixes a minor bug in #35 where water runways with condition information (e.g. WATER-E) get the default color of grey instead of the blue that they should have. Most water runways have no listed condition letter, so this only affects a few airports where for whatever reason the AMR indicates the conditon of the water.

![Screenshot from 2024-11-19 17-01-16](https://github.com/user-attachments/assets/2d2cf29c-923c-452e-8610-54fdca2e50bf)
