### PR TITLE
Align skew-t printout to fill whole screen

### DIFF
--- a/lib/weather/sounding.dart
+++ b/lib/weather/sounding.dart
@@ -47,7 +47,7 @@ class Sounding {
           showDialog(context: context,
             builder: (BuildContext context) => Dialog.fullscreen(
               child: Stack(children:[
-                InteractiveViewer(child: Container(color: Colors.white ,child: image)),
+                InteractiveViewer(child: Container(color: Colors.white ,child: image, alignment: Alignment.center)),
                 Align(alignment: Alignment.topRight, child: IconButton(onPressed: () => Navigator.pop(context), icon: const Icon(Icons.close, size: 36, color: Colors.grey)))
               ])
             ));


### PR DESCRIPTION
Fixes an issue with the printout of Skew-T plots where zooming in does not use additional screen area. This is particularly manifest when viewing in portrait mode, since about two thirds of the screen is unusable.

Before:
![Screenshot_20241203_120146](https://github.com/user-attachments/assets/0614fee2-13b9-4aad-9447-5fe97eb06ba2)

After:
![Screenshot_20241203_115837](https://github.com/user-attachments/assets/37083e30-c07c-43bc-93e3-e472c626540b)
