### PR TITLE
Add magnetic variation support for airport diagrams

### DIFF
--- a/lib/destination/airport.dart
+++ b/lib/destination/airport.dart
@@ -313,7 +313,7 @@ class RunwayPainter extends CustomPainter {
     try {
       String surf = r['Surface'];
 
-      if(surf.substring(0,5) == 'WATER') {
+      if(surf.length >= 5 && surf.substring(0,5) == 'WATER') {
         surfcolor = Colors.blue;
       }
       else {

--- a/lib/destination/destination.dart
+++ b/lib/destination/destination.dart
@@ -266,7 +266,6 @@ class AirportDestination extends Destination {
   final List<Map<String, dynamic>> awos;
   final String unicom;
   final String ctaf;
-  final String variation;
 
   AirportDestination({
     required super.locationID,
@@ -279,7 +278,6 @@ class AirportDestination extends Destination {
     required this.runways,
     required this.unicom,
     required this.ctaf,
-    required this.variation
   });
 
 
@@ -304,7 +302,6 @@ class AirportDestination extends Destination {
         unicom: maps['UNICOMFrequencies'] as String,
         frequencies: mapsFreq,
         awos: mapsAwos,
-        variation: maps['MagneticVariation'] as String,
         runways: mapsRunways
     );
   }

--- a/lib/destination/destination.dart
+++ b/lib/destination/destination.dart
@@ -266,6 +266,7 @@ class AirportDestination extends Destination {
   final List<Map<String, dynamic>> awos;
   final String unicom;
   final String ctaf;
+  final String variation;
 
   AirportDestination({
     required super.locationID,
@@ -277,7 +278,8 @@ class AirportDestination extends Destination {
     required this.awos,
     required this.runways,
     required this.unicom,
-    required this.ctaf
+    required this.ctaf,
+    required this.variation
   });
 
 
@@ -302,6 +304,7 @@ class AirportDestination extends Destination {
         unicom: maps['UNICOMFrequencies'] as String,
         frequencies: mapsFreq,
         awos: mapsAwos,
+        variation: maps['MagneticVariation'] as String,
         runways: mapsRunways
     );
   }

--- a/lib/destination/destination.dart
+++ b/lib/destination/destination.dart
@@ -277,7 +277,7 @@ class AirportDestination extends Destination {
     required this.awos,
     required this.runways,
     required this.unicom,
-    required this.ctaf,
+    required this.ctaf
   });
 
 


### PR DESCRIPTION
Adds a printout for airports with published magnetic variation information to the left side printout.

For runways with no positional information, the method for calculating the drawn orientation of the model now compensates for the reported magnetic variation. 

If no data is provided (many private airports), then no magnetic variation information is provided and no compensation is performed.

Additionally, fixes an airport diagram rendering bug where runways with no condition modifier (e.g. CONC **-E** ) were drawn in grey instead of whatever color they would be drawn in given their surface type.

Before:
![Screenshot from 2024-12-21 15-11-09](https://github.com/user-attachments/assets/b2c998d2-9f82-40ec-87c9-8023f0f1a7bb)
After:

![Screenshot from 2024-12-21 23-17-25](https://github.com/user-attachments/assets/e8145c22-3f5e-4184-882d-880cee75a565)

This snippet from the SEA TAC chart confirms the variation is applied in the correct direction:
![Screenshot from 2024-12-21 15-15-41](https://github.com/user-attachments/assets/865edd8a-b26e-4a4c-8a00-08d7220617c1)

P.S. The indicated length in the airport diagram vs the TAC chart is not a bug. The TAC chart only publishes length of the paved section, and this runway has 1600 ft of pavement + 1400 ft of turf. I don't have the information to properly render that.
