### PR TITLE
Stratux automagic reverse PFD/AHRS roll orientation

### DIFF
--- a/lib/gdl90/ahrs_message.dart
+++ b/lib/gdl90/ahrs_message.dart
@@ -4,6 +4,8 @@ import 'package:avaremp/pfd_painter.dart';
 
 import 'message.dart';
 
+bool isStratux = false;  // share state with message_factory.dart
+
 class AhrsMessage extends Message {
 
   double? aoa;
@@ -119,7 +121,8 @@ class AhrsMessage extends Message {
         double num;
         num = _combineBytesForFloat(m0, m1);
         if (num != 0x7FFF) {
-          roll = num / 10;
+          // roll = num / 10;
+          roll = (isStratux == true) ? -(num / 10) : (num / 10);  // reverse roll orientation
         }
         num = _combineBytesForFloat(m2, m3);
         if (num != 0x7FFF) {

--- a/lib/gdl90/message_factory.dart
+++ b/lib/gdl90/message_factory.dart
@@ -26,6 +26,9 @@ class MessageFactory
     switch (type) {
       case MessageType.heartBeat:
         break;
+      case MessageType.heartBeatStratux:
+        isStratux = true;
+        break;
       case MessageType.uplink:
         m = UplinkMessage(type);
       case MessageType.ownShip:
@@ -96,6 +99,7 @@ class MessageFactory
 
 class MessageType {
   static const int heartBeat = 0x00;
+  static const int heartBeatStratux = 0xCC;  // per https://github.com/cyoung/stratux/blob/master/notes/app-vendor-integration.md
   static const int uplink = 0x07;
   static const int ownShip = 0x0A;
   static const int ownShipGeometricAltitude = 0x0B;


### PR DESCRIPTION
Auto-detect stratux as the GDL90 provider via additional identifying heartbeat messages per https://github.com/cyoung/stratux/blob/master/notes/app-vendor-integration.md and reverse the roll orientation accordingly.

The recognition logic of 0xCC is the preferred identification method, and stable with the newer/current @b3nn0 branch of stratux: https://github.com/b3nn0/stratux

The isStratux() state could be used more broadly if desired (e.g. "Additional data/control available to EFBs" in the first URL).

