### PR TITLE
TFR (Internet) quick fix due to FAA tfr3 breaking things.

### DIFF
--- a/lib/weather/tfr_cache.dart
+++ b/lib/weather/tfr_cache.dart
@@ -22,18 +22,22 @@ class TfrCache extends WeatherCache {
     String decoded = utf8.decode(data[0]);
 
     // parse for https://tfr.faa.gov/save_pages/detail_4_6599.html
-    RegExp exp = RegExp("save_pages/detail_[0-9]*_[0-9]*.html");
+    // RegExp exp = RegExp("save_pages/detail_[0-9]*_[0-9]*.html");
+    // 2025-02-27, bspatz: now JSON "notam_id" : "5/7572"
+    RegExp exp = RegExp('"notam_id" : "[0-9]*/[0-9]*"');
 
     Iterable<RegExpMatch> matches = exp.allMatches(decoded);
     List<String?> unique = matches.map((e) => e[0]).toSet().toList();
     for(String? match in unique) {
       if(null != match) {
-        match = match.replaceAll(".html", ".xml");
+        //match = match.replaceAll(".html", ".xml");
+        match = match.split(':')[1].trim().replaceAll("/", "_").replaceAll('"','');
       }
       else {
         continue;
       }
-      String url = "https://tfr.faa.gov/$match";
+      // String url = "https://tfr.faa.gov/$match";
+      String url = "https://tfr.faa.gov/download/detail_$match.xml";
       // now download each TFR
       http.Response response = await http.get(Uri.parse(url));
       decoded = utf8.decode(response.bodyBytes);

--- a/lib/weather/tfr_cache.dart
+++ b/lib/weather/tfr_cache.dart
@@ -21,23 +21,13 @@ class TfrCache extends WeatherCache {
     final List<Tfr> tfrs = [];
     String decoded = utf8.decode(data[0]);
 
-    // parse for https://tfr.faa.gov/save_pages/detail_4_6599.html
-    // RegExp exp = RegExp("save_pages/detail_[0-9]*_[0-9]*.html");
-    // 2025-02-27, bspatz: now JSON "notam_id" : "5/7572"
-    RegExp exp = RegExp('"notam_id" : "[0-9]*/[0-9]*"');
+    // As of 2025-02-28 we fetch a JSON list of TFRs, so simply parse notam_id as "3/9568"
+    // to fetch https://tfr.faa.gov/download/detail_3_9568.xml and process as before
+    var tfr_Array = jsonDecode(decoded);
+    for(final tfr_Obj in tfr_Array) {
+      String nid = tfr_Obj["notam_id"].toString().replaceAll('/','_');
+      String url = "https://tfr.faa.gov/download/detail_$nid.xml";
 
-    Iterable<RegExpMatch> matches = exp.allMatches(decoded);
-    List<String?> unique = matches.map((e) => e[0]).toSet().toList();
-    for(String? match in unique) {
-      if(null != match) {
-        //match = match.replaceAll(".html", ".xml");
-        match = match.split(':')[1].trim().replaceAll("/", "_").replaceAll('"','');
-      }
-      else {
-        continue;
-      }
-      // String url = "https://tfr.faa.gov/$match";
-      String url = "https://tfr.faa.gov/download/detail_$match.xml";
       // now download each TFR
       http.Response response = await http.get(Uri.parse(url));
       decoded = utf8.decode(response.bodyBytes);

--- a/lib/weather/weather_cache.dart
+++ b/lib/weather/weather_cache.dart
@@ -146,7 +146,8 @@ class WeatherCache {
     else if(type == TfrCache) {
       // default
       WeatherCache cache = TfrCache(
-          ["https://tfr.faa.gov/tfr2/list.html"],
+          //["https://tfr.faa.gov/tfr2/list.html"],
+          ["https://tfr.faa.gov/tfrapi/getTfrList"], // noticed/changed 2025-02-27
           WeatherDatabaseHelper.db.getAllTfr);
       return cache;
     }


### PR DESCRIPTION
Use master TFR list as JSON (was XML), parse JSON directly (no regexp/match) and fetch for detail XML as usual .  Better fix?  ZK can decide.
https://tfr.faa.gov/tfrapi/getTfrList