### PR TITLE
Internet-provided NOTAMs: put longpress airport at top of list.

### DIFF
--- a/lib/weather/notam_cache.dart
+++ b/lib/weather/notam_cache.dart
@@ -93,18 +93,28 @@ class NotamCache extends WeatherCache {
       return;
     }
 
-    String ll = Destination.toSexagesimal(airport.coordinate);
-
+    // 2025-03-13, bspatz: use airport-ID based search instead of lat/long; same DINS source
+    //                     yields same NOTAM set, but longpress airport at top
+    String _icaoID = airport.locationID;
+    if (_icaoID[0] != "K") { _icaoID = "K" + _icaoID; }  // naive for US only?
+    
+    //String ll = Destination.toSexagesimal(airport.coordinate);
     Map<String, String> body = {
-      "geoLatDegree": ll.substring(0, 3),
-      "geoLatMinute": ll.substring(3, 5),
-      "geoLatNorthSouth": ll.substring(7, 8),
-      "geoLongDegree": ll.substring(9, 12),
-      "geoLongMinute": ll.substring(12, 14),
-      "geoLongEastWest": ll.substring(16, 17),
-      "reportType": "Raw",
-      "geoLatLongRadius": "20",
-      "actionType": "latLongSearch",
+      //"geoLatDegree": ll.substring(0, 3),
+      //"geoLatMinute": ll.substring(3, 5),
+      //"geoLatNorthSouth": ll.substring(7, 8),
+      //"geoLongDegree": ll.substring(9, 12),
+      //"geoLongMinute": ll.substring(12, 14),
+      //"geoLongEastWest": ll.substring(16, 17),
+      //"reportType": "Raw",
+      //"geoLatLongRadius": "20",
+      //"actionType": "latLongSearch",
+      
+      "geoIcaoLocId": _icaoID,
+      "reportType": "Raw",        // unused?  from top DINS page FORM; keeping for ZK
+      "geoIcaoRadius": "20",      // could be Storage().settings.getStealthSetting("key-notam-radius", "20"),
+      "actionType": "radiusSearch",
+      
       "submit": "View+NOTAMs",
     };
 

--- a/lib/weather/weather_cache.dart
+++ b/lib/weather/weather_cache.dart
@@ -173,7 +173,8 @@ class WeatherCache {
     else if(type == NotamCache) {
       // default
       WeatherCache cache = NotamCache(
-          ["https://www.notams.faa.gov/dinsQueryWeb/latLongRadiusSearchMapAction.do"],
+          // ["https://www.notams.faa.gov/dinsQueryWeb/latLongRadiusSearchMapAction.do"],
+          ["https://www.notams.faa.gov/dinsQueryWeb/icaoRadiusSearchMapAction.do"],
           WeatherDatabaseHelper.db.getAllNotams);
       return cache;
     }


### PR DESCRIPTION
By using the same FAA DINS web site https://www.notams.faa.gov/dinsQueryWeb/, but using the ICAO Radius Search instead of the current Lat/Long Radius Search, the results have the longpress airport listed at the top, rather than randomly down the list of all airports in the 20nm search radius.

Several forum users have asked for this, and seems more intuitive to me.
https://groups.google.com/g/apps4av-forum/c/5yvXVngldeo/m/FbNoTHg4AQAJ

I recognize there are different ways to accomplish putting the longpress airport at the top, but I wanted to respect the current approach which does limited parsing of the DINS web page scrape.  But by using an adjacent query/API, the result set is the same but ordered with the airport of interest (subject of the longpress) at the top.  Of course that could change if DINS changes their ordering.   I recognize additional parsing could break down these results into per-location rows for the database/cache, with AvareX database queries then using ORDER BY for sorting by distance to longpress, etc.

Screenshots of before and after for X60:
![NOTAM-before](https://github.com/user-attachments/assets/e4e5008f-1fc8-4d2f-80ed-f1a5a1543fff)
![NOTAM-after](https://github.com/user-attachments/assets/9b6da06e-5f04-462e-b8b4-857a0093d66f)
