### PR TITLE
Filter ownship from traffic using selected aircraft (ICAO ID & tail #/callsign)

### DIFF
--- a/lib/aircraft_screen.dart
+++ b/lib/aircraft_screen.dart
@@ -59,6 +59,7 @@ class AircraftScreenState extends State<AircraftScreen> {
                 setState(() {
                   _selected = value;
                   Storage().settings.setAircraft(value!);
+                  Storage().loadAircraftIds();
                 });
               },
             )
@@ -122,6 +123,7 @@ class AircraftScreenState extends State<AircraftScreen> {
                           String? entry = _selected;
                           if(null != entry) {
                             UserDatabaseHelper.db.deleteAircraft(entry);
+                            Storage().loadAircraftIds();
                           }
                           Storage().settings.setChecklist("");
                           setState(() {
@@ -139,6 +141,7 @@ class AircraftScreenState extends State<AircraftScreen> {
                         UserDatabaseHelper.db.addAircraft(a).then((value) {
                           setState(() {
                             Storage().settings.setAircraft(a.tail);
+                            Storage().loadAircraftIds();
                           });
                         });
                       },

--- a/lib/data/user_database_helper.dart
+++ b/lib/data/user_database_helper.dart
@@ -309,6 +309,7 @@ class UserDatabaseHelper {
     if (db != null) {
       await DbGeneral.insert(db, "aircraft", aircraft.toMap());
     }
+    Storage().loadAircraftIds();
   }
 
   Future<void> deleteAircraft(String name) async {
@@ -317,6 +318,7 @@ class UserDatabaseHelper {
     if (db != null) {
       await DbGeneral.query(db, "delete from aircraft where tail='$name'");
     }
+    Storage().loadAircraftIds();
   }
 
   Future<List<Aircraft>> getAllAircraft() async {

--- a/lib/data/user_database_helper.dart
+++ b/lib/data/user_database_helper.dart
@@ -309,7 +309,6 @@ class UserDatabaseHelper {
     if (db != null) {
       await DbGeneral.insert(db, "aircraft", aircraft.toMap());
     }
-    Storage().loadAircraftIds();
   }
 
   Future<void> deleteAircraft(String name) async {
@@ -318,7 +317,6 @@ class UserDatabaseHelper {
     if (db != null) {
       await DbGeneral.query(db, "delete from aircraft where tail='$name'");
     }
-    Storage().loadAircraftIds();
   }
 
   Future<List<Aircraft>> getAllAircraft() async {

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -110,8 +110,8 @@ class TrafficCache {
 
     // filter own report
     if(message.icao == Storage().ownshipMessageIcao 
-      || Storage().myAircraftIcaos.contains(message.icao)
-      || Storage().myAircraftCallsigns.contains(message.callSign)) 
+      || Storage().myAircraftIcao == message.icao
+      || Storage().myAircraftCallsign == message.callSign) 
     {
       // do not add ourselves
       return;

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -109,7 +109,10 @@ class TrafficCache {
   void putTraffic(TrafficReportMessage message) {
 
     // filter own report
-    if(message.icao == Storage().myIcao) {
+    if(message.icao == Storage().ownshipMessageIcao 
+      || Storage().myAircraftIcaos.contains(message.icao)
+      || Storage().myAircraftCallsigns.contains(message.callSign)) 
+    {
       // do not add ourselves
       return;
     }

--- a/lib/gdl90/traffic_cache.dart
+++ b/lib/gdl90/traffic_cache.dart
@@ -579,7 +579,7 @@ class TrafficIdPainter extends AbstractCachedCustomPainter {
   static final _boundingBoxPaint = Paint()..color = const Color.fromRGBO(0, 0, 0, .2);
   static const _trafficIdTextStyle = TextStyle(shadows: [Shadow(offset: Offset(2, 2))], color: Colors.white, fontWeight: FontWeight.w600, fontSize: _trafficIdFontSize);
   static const double _offsetX = 24, _offsetY = 24;
-  static const double _charPixeslWidth = 11;
+  static const double _charPixeslWidth = 12;
 
   final String _trafficId;
   final bool _isAirborne;

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -4,8 +4,10 @@ import 'dart:ui' as ui;
 
 // put all singletons here.
 
+import 'package:avaremp/aircraft.dart';
 import 'package:avaremp/area.dart';
 import 'package:avaremp/data/main_database_helper.dart';
+import 'package:avaremp/data/user_database_helper.dart';
 import 'package:avaremp/download_screen.dart';
 import 'package:avaremp/flight_status.dart';
 import 'package:avaremp/gdl90/ahrs_message.dart';
@@ -86,7 +88,9 @@ class Storage {
   final Area area = Area();
   final TrafficCache trafficCache = TrafficCache();
   final StackWithOne<Position> _gpsStack = StackWithOne(Gps.centerUSAPosition());
-  int myIcao = 0;
+  List<int> myAircraftIcaos = [];
+  List<String> myAircraftCallsigns = [];
+  int ownshipMessageIcao = 0;
   PfdData pfdData = PfdData(); // a place to drive PFD
   GpsRecorder tracks = GpsRecorder();
   late final FlightTimer flightTimer;
@@ -190,7 +194,7 @@ class Storage {
         if (null != message) {
           Message? m = MessageFactory.buildMessage(message);
           if(m != null && m is OwnShipMessage) {
-            myIcao = m.icao;
+            ownshipMessageIcao = m.icao;
             Position p = Position(longitude: m.coordinates.longitude, latitude: m.coordinates.latitude, timestamp: DateTime.timestamp(), accuracy: 0, altitude: m.altitude, altitudeAccuracy: 0, heading: m.heading, headingAccuracy: 0, speed: m.velocity, speedAccuracy: 0);
             _lastMsGpsSignal = DateTime.now().millisecondsSinceEpoch; // update time when GPS signal was last received
             _lastMsExternalSignal = _lastMsGpsSignal; // start ignoring internal GPS
@@ -229,7 +233,7 @@ class Storage {
           NmeaMessage? m = NmeaMessageFactory.buildMessage(message);
           if(m != null && m is NmeaOwnShipMessage) {
             NmeaOwnShipMessage m0 = m;
-            myIcao = m0.icao;
+            ownshipMessageIcao = m0.icao;
             Position p = Position(longitude: m0.coordinates.longitude, latitude: m0.coordinates.latitude, timestamp: DateTime.timestamp(), accuracy: 0, altitude: m0.altitude, altitudeAccuracy: 0, heading: m0.heading, headingAccuracy: 0, speed: m0.velocity, speedAccuracy: 0);
             _lastMsGpsSignal = DateTime.now().millisecondsSinceEpoch; // update time when GPS signal was last received
             _lastMsExternalSignal = _lastMsGpsSignal; // start ignoring internal GPS
@@ -301,6 +305,9 @@ class Storage {
     settings.setZoom(10);
     settings.setCenterLatitude(position.latitude);
     settings.setCenterLongitude(position.longitude);
+
+    // don't await on this, but set when available, as DB access could take a few ms
+    loadAircraftIds();
 
     // this is a long login process, do not await here
 
@@ -376,6 +383,27 @@ class Storage {
     });
 
     downloadWeather();
+  }
+
+  Future<void> loadAircraftIds() async {
+    myAircraftIcaos = [];
+    myAircraftCallsigns = [];
+    for (Aircraft a in await UserDatabaseHelper.db.getAllAircraft()) {
+      if (a.icao.isNotEmpty) {
+        try {
+          myAircraftIcaos.add(a.icao.trim().length > 6 ? int.parse(a.icao) : int.parse(a.icao, radix: 16));
+        } catch (e) {
+          // ignore
+        }
+      }
+      if (a.tail.isNotEmpty) {
+        try {
+          myAircraftCallsigns.add(a.tail.trim().toUpperCase());
+        } catch (e) {
+          // ignore
+        }
+      }
+    }
   }
 
   Future<void> downloadWeather() async {

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -88,7 +88,7 @@ class Storage {
   final Area area = Area();
   final TrafficCache trafficCache = TrafficCache();
   final StackWithOne<Position> _gpsStack = StackWithOne(Gps.centerUSAPosition());
-  int myAircraftIcao = -1;
+  int myAircraftIcao = 0;
   String myAircraftCallsign = "";
   int ownshipMessageIcao = 0;
   PfdData pfdData = PfdData(); // a place to drive PFD
@@ -390,7 +390,7 @@ class Storage {
     if (acName.isEmpty) {
       // Reset, if there is no longer any aircraft selected (say all were deleted)
       myAircraftCallsign = "";
-      myAircraftIcao = -1;
+      myAircraftIcao = 0;
       return;
     }
     try {
@@ -407,7 +407,7 @@ class Storage {
       }
     } catch (e) {
       myAircraftCallsign = "";
-      myAircraftIcao = -1;
+      myAircraftIcao = 0;
     }
   }
 

--- a/tests/gdl90_test.py
+++ b/tests/gdl90_test.py
@@ -1,7 +1,12 @@
 import socket
 import time
+import sys
 
-infile = input("Enter file name:")
+if len(sys.argv) > 1:
+    infile = sys.argv[1]
+else:
+    infile = input("Enter file name:")
+print("Reading ADSB data from file: " + infile)
 while True:
     file = open(infile, "rb")
 


### PR DESCRIPTION
Addressing issues #38 and #63 , this PR filters our ICAO ID's and callsigns/tail numbers that are configured in the selected aircraft page/database. 

Also, while testing this, I noticed two things, one a fairly important bug and the other a nicety I added to the GDL90 test app (which of course I used a lot to test this, and I have used heavily in the past to test traffic changes):

1. Fixed traffic ID display that was cutting off the final character of the tail number (on Windows, at least) for tail numbers that had "large" (using the default non-monospace font) letters at the end, like "W" (noticed with the nearby N424W in the adsb_lancaster.bin ADSB recording)
2. Added a CLI filename param option to the GLD90 test python app, as this made repeated run/re-runs much easier than having to type the filename every time.