### PR TITLE
Integrate revenuecat for pro access screen

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -60,6 +60,14 @@ class Constants {
   static const String appleId = "6502421523";
   static const String microsoftId = "9MX4HKL30MWW";
 
+  // RevenueCat configuration
+  // Fill these with your RevenueCat public SDK keys per platform
+  static const String revenueCatPublicSdkKeyAndroid = ""; // e.g. rc_android_key_... 
+  static const String revenueCatPublicSdkKeyIOS = ""; // e.g. rc_ios_key_...
+  static const String revenueCatPublicSdkKeyMacOS = ""; // optional if different
+  static const String revenueCatPublicSdkKeyWindows = ""; // optional if different
+  static const String revenueCatEntitlementPro = "pro";
+
   static double dropDownButtonFontSize = 14;
 
   static double carouselAspectRatio(BuildContext context) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,9 @@ import 'package:avaremp/wnb_screen.dart';
 import 'package:avaremp/writing_screen.dart';
 import 'package:flutter/material.dart';
 import 'aircraft_screen.dart';
+import 'package:avaremp/pro_screen.dart';
+import 'package:avaremp/revenuecat_service.dart';
+import 'package:avaremp/upgrade_screen.dart';
 import 'checklist_screen.dart';
 import 'constants.dart';
 import 'destination/destination.dart';
@@ -25,7 +28,8 @@ void main()  {
   // this is to control cache. Nexrad needs it or image caching will make it impossible to animate weather
   CustomWidgetsBinding();
 
-  Storage().init().then((accentColor) {
+  Storage().init().then((accentColor) async {
+    await RevenueCatService().init();
     runApp(const MainApp());
   });
 
@@ -61,6 +65,8 @@ class MainApp extends StatelessWidget {
                   final args = ModalRoute.of(context)!.settings.arguments as List<Destination>;
                   return LongPressScreen(destinations: args);
                 }
+              , '/pro': (context) => const ProScreen()
+              , '/upgrade': (context) => const UpgradeScreen()
             },
             theme: value,
           )); // Safe Area so things from OS do not get in the way

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -9,6 +9,7 @@ import 'map_screen.dart';
 import 'find_screen.dart';
 import 'package:yaml/yaml.dart';
 import 'package:flutter/services.dart';
+import 'package:avaremp/revenuecat_service.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({super.key});
@@ -141,6 +142,19 @@ class MainScreenState extends State<MainScreen> with WidgetsBindingObserver { //
               ListTile(title: const Text("Log Book"), leading: Icon(Icons.notes), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/logbook');}, dense: true,),
               if(Constants.shouldShowBluetoothSpp) ListTile(title: const Text("IO"), leading: const Icon(Icons.compare_arrows_rounded), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/io');}, dense: true,),
               if(Constants.shouldShowDonation) ListTile(title: const Text("Donate"), leading: const Icon(Icons.celebration), onTap: () {Navigator.pushNamed(context, '/donate');}, dense: true,),
+              ListTile(title: const Text("AvareX Pro"), leading: const Icon(Icons.star), onTap: () async {
+                Navigator.pop(context);
+                final bool pro = await RevenueCatService().isProUser();
+                if (pro) {
+                  if (mounted) {
+                    Navigator.pushNamed(context, '/pro');
+                  }
+                } else {
+                  if (mounted) {
+                    Navigator.pushNamed(context, '/upgrade');
+                  }
+                }
+              }, dense: true,),
             ],
           ))
         ),

--- a/lib/pro_screen.dart
+++ b/lib/pro_screen.dart
@@ -1,0 +1,48 @@
+import 'package:avaremp/revenuecat_service.dart';
+import 'package:flutter/material.dart';
+
+class ProScreen extends StatefulWidget {
+  const ProScreen({super.key});
+
+  @override
+  State<ProScreen> createState() => _ProScreenState();
+}
+
+class _ProScreenState extends State<ProScreen> {
+  bool _checked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _guardAccess();
+  }
+
+  Future<void> _guardAccess() async {
+    final bool pro = await RevenueCatService().isProUser();
+    if (!pro && mounted) {
+      Navigator.pushReplacementNamed(context, '/upgrade');
+    } else if (mounted) {
+      setState(() {
+        _checked = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_checked) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AvareX Pro'),
+      ),
+      body: const Center(
+        child: Text('Welcome to AvareX Pro features'),
+      ),
+    );
+  }
+}
+

--- a/lib/revenuecat_service.dart
+++ b/lib/revenuecat_service.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:avaremp/constants.dart';
+import 'package:flutter/foundation.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+class RevenueCatService {
+  RevenueCatService._internal();
+  static final RevenueCatService _instance = RevenueCatService._internal();
+  factory RevenueCatService() => _instance;
+
+  final ValueNotifier<bool> isPro = ValueNotifier<bool>(false);
+  bool _isConfigured = false;
+
+  bool get isSupportedPlatform {
+    if (kIsWeb) {
+      return false;
+    }
+    if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS || Platform.isWindows) {
+      return true;
+    }
+    return false; // treat Linux as unsupported
+  }
+
+  Future<void> init() async {
+    if (!isSupportedPlatform) {
+      // Treat unsupported platforms as Pro-enabled so features remain accessible
+      isPro.value = true;
+      return;
+    }
+
+    if (_isConfigured) {
+      return;
+    }
+
+    String? apiKey;
+    if (Platform.isAndroid) {
+      apiKey = Constants.revenueCatPublicSdkKeyAndroid;
+    } else if (Platform.isIOS) {
+      apiKey = Constants.revenueCatPublicSdkKeyIOS;
+    } else if (Platform.isMacOS) {
+      apiKey = Constants.revenueCatPublicSdkKeyMacOS.isNotEmpty
+          ? Constants.revenueCatPublicSdkKeyMacOS
+          : Constants.revenueCatPublicSdkKeyIOS;
+    } else if (Platform.isWindows) {
+      apiKey = Constants.revenueCatPublicSdkKeyWindows.isNotEmpty
+          ? Constants.revenueCatPublicSdkKeyWindows
+          : Constants.revenueCatPublicSdkKeyAndroid;
+    }
+
+    if (apiKey == null || apiKey.isEmpty) {
+      // If no key provided, consider Pro disabled but don't crash
+      isPro.value = false;
+      return;
+    }
+
+    final configuration = PurchasesConfiguration(apiKey);
+    await Purchases.configure(configuration);
+    _isConfigured = true;
+    await refreshCustomerInfo();
+  }
+
+  Future<void> refreshCustomerInfo() async {
+    if (!isSupportedPlatform || !_isConfigured) {
+      return;
+    }
+    try {
+      final CustomerInfo info = await Purchases.getCustomerInfo();
+      final bool hasPro = info.entitlements.active.containsKey(Constants.revenueCatEntitlementPro);
+      isPro.value = hasPro;
+    } catch (_) {
+      isPro.value = false;
+    }
+  }
+
+  Future<bool> isProUser() async {
+    if (!isSupportedPlatform) {
+      return true;
+    }
+    await refreshCustomerInfo();
+    return isPro.value;
+  }
+}
+

--- a/lib/upgrade_screen.dart
+++ b/lib/upgrade_screen.dart
@@ -1,0 +1,84 @@
+import 'package:avaremp/revenuecat_service.dart';
+import 'package:flutter/material.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+
+class UpgradeScreen extends StatefulWidget {
+  const UpgradeScreen({super.key});
+
+  @override
+  State<UpgradeScreen> createState() => _UpgradeScreenState();
+}
+
+class _UpgradeScreenState extends State<UpgradeScreen> {
+  Offerings? _offerings;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOfferings();
+  }
+
+  Future<void> _loadOfferings() async {
+    try {
+      final Offerings offerings = await Purchases.getOfferings();
+      setState(() {
+        _offerings = offerings;
+        _loading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _purchase(Package package) async {
+    try {
+      await Purchases.purchasePackage(package);
+      await RevenueCatService().refreshCustomerInfo();
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Upgrade to Pro')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(child: Text('Error: $_error'))
+              : _offerings == null
+                  ? const Center(child: Text('No offerings available'))
+                  : ListView(
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        if (_offerings!.current != null)
+                          ..._offerings!.current!.availablePackages.map((p) {
+                            final product = p.storeProduct;
+                            return Card(
+                              child: ListTile(
+                                title: Text(product.title),
+                                subtitle: Text(product.description),
+                                trailing: Text(product.priceString),
+                                onTap: () => _purchase(p),
+                              ),
+                            );
+                          })
+                        else
+                          const Text('No current offering configured')
+                      ],
+                    ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ dependencies:
   geojson_vi: ^2.2.5
   csv: ^5.0.0
   flutter_bluetooth_serial_ble: ^0.5.0
+  purchases_flutter: ^6.29.0
   # 2024-07-20 Shane Lenagh: Old MSVC library crash issue workaround (for audioplayers in audible alerts): https://github.com/YehudaKremer/msix/issues/272#issuecomment-2181634105
   msvcredist:
     git:


### PR DESCRIPTION
Integrate RevenueCat to enable 'Pro' level access, adding a dedicated Pro screen and an upgrade flow, accessible via a new drawer item.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b5f3295-ecac-4d52-92c9-3fe4e4a4d22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b5f3295-ecac-4d52-92c9-3fe4e4a4d22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

