### PR TITLE
Integrate chatgpt with chat screen

### DIFF
--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -253,4 +253,21 @@ class AppSettings {
     provider.setBool("key-review-never", true);
   }
 
+  // OpenAI / ChatGPT settings
+  void setOpenAIKey(String key) {
+    provider.setString("key-openai-api-key", key);
+  }
+
+  String getOpenAIKey() {
+    return provider.getValue("key-openai-api-key", defaultValue: "") as String;
+  }
+
+  void setOpenAIModel(String model) {
+    provider.setString("key-openai-model", model);
+  }
+
+  String getOpenAIModel() {
+    return provider.getValue("key-openai-model", defaultValue: "gpt-4o-mini") as String;
+  }
+
 }

--- a/lib/chat_screen.dart
+++ b/lib/chat_screen.dart
@@ -1,0 +1,198 @@
+import 'package:avaremp/app_settings.dart';
+import 'package:avaremp/constants.dart';
+import 'package:avaremp/openai_service.dart';
+import 'package:avaremp/progress_button_message_input_widget.dart';
+import 'package:avaremp/storage.dart';
+import 'package:flutter/material.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key});
+
+  @override
+  State<StatefulWidget> createState() => ChatScreenState();
+}
+
+class ChatScreenState extends State<ChatScreen> {
+
+  final TextEditingController _controller = TextEditingController();
+  final List<Map<String, String>> _messages = [];
+  bool _sending = false;
+  String _error = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AppSettings settings = Storage().settings;
+    final bool missingKey = settings.getOpenAIKey().isEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Constants.appBarBackgroundColor,
+        title: const Text('AI Chat'),
+      ),
+      body: Column(
+        children: <Widget>[
+          if (missingKey)
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: <Widget>[
+                  const Expanded(
+                    child: Text(
+                      'OpenAI API key is not set. Configure to start chatting.',
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: _openSettingsDialog,
+                    child: const Text('Configure'),
+                  )
+                ],
+              ),
+            ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(12),
+              itemCount: _messages.length,
+              itemBuilder: (BuildContext context, int index) {
+                final Map<String, String> msg = _messages[index];
+                final bool isUser = msg['role'] == 'user';
+                return Align(
+                  alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 6),
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: isUser ? theme.colorScheme.primary : theme.colorScheme.surfaceVariant,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      msg['content'] ?? '',
+                      style: TextStyle(
+                        color: isUser ? Colors.white : theme.colorScheme.onSurface,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          if (_error.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(_error, style: const TextStyle(color: Colors.red)),
+              ),
+            ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: <Widget>[
+                  IconButton(
+                    onPressed: _openSettingsDialog,
+                    icon: const Icon(Icons.settings),
+                    tooltip: 'Chat settings',
+                  ),
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      minLines: 1,
+                      maxLines: 4,
+                      decoration: const InputDecoration(
+                        hintText: 'Type a message...',
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      onSubmitted: (_) => _onSend(),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  _sending
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : IconButton(
+                          onPressed: _onSend,
+                          icon: const Icon(Icons.send),
+                          tooltip: 'Send',
+                        ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openSettingsDialog() {
+    final AppSettings settings = Storage().settings;
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          content: ProgressButtonMessageInputWidget(
+            'OpenAI Settings',
+            'Model',
+            settings.getOpenAIModel(),
+            'API Key',
+            settings.getOpenAIKey(),
+            'Save',
+            (List<String> args) async {
+              try {
+                await settings.setOpenAIModel(args[0]);
+                await settings.setOpenAIKey(args[1]);
+                return '';
+              } catch (e) {
+                return e.toString();
+              }
+            },
+            (bool ok, String model, String key) {
+              if (ok) {
+                setState(() {});
+                Navigator.of(context).pop();
+              }
+            },
+            'Saved',
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _onSend() async {
+    final String text = _controller.text.trim();
+    if (text.isEmpty || _sending) {
+      return;
+    }
+    setState(() {
+      _error = '';
+      _sending = true;
+      _messages.add({'role': 'user', 'content': text});
+      _controller.clear();
+    });
+
+    try {
+      final OpenAIService service = OpenAIService.fromSettings();
+      final String reply = await service.chat(_messages);
+      setState(() {
+        _messages.add({'role': 'assistant', 'content': reply});
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _sending = false;
+        });
+      }
+    }
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'constants.dart';
 import 'destination/destination.dart';
 import 'documents_screen.dart';
 import 'download_screen.dart';
+import 'chat_screen.dart';
 import 'io_screen.dart';
 import 'main_screen.dart';
 import 'onboarding_screen.dart';
@@ -56,6 +57,7 @@ class MainApp extends StatelessWidget {
               '/donate': (context) => const DonateScreen(),
               if(Constants.shouldShowBluetoothSpp) '/io': (context) => const IoScreen(),
               '/notes': (context) => const WritingScreen(),
+              '/chat': (context) => const ChatScreen(),
               '/plan_actions': (context) => const PlanActionScreen(),
               '/popup': (context) {
                   final args = ModalRoute.of(context)!.settings.arguments as List<Destination>;

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -139,6 +139,7 @@ class MainScreenState extends State<MainScreen> with WidgetsBindingObserver { //
               ListTile(title: const Text("Check Lists"), leading: Icon(MdiIcons.check), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/checklists');}, dense: true,),
               ListTile(title: const Text("W&B"), leading: Icon(MdiIcons.scaleUnbalanced), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/wnb');}, dense: true,),
               ListTile(title: const Text("Log Book"), leading: Icon(Icons.notes), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/logbook');}, dense: true,),
+              ListTile(title: const Text("AI Chat"), leading: const Icon(Icons.chat_bubble_outline), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/chat');}, dense: true,),
               if(Constants.shouldShowBluetoothSpp) ListTile(title: const Text("IO"), leading: const Icon(Icons.compare_arrows_rounded), onTap: () {Navigator.pop(context); Navigator.pushNamed(context, '/io');}, dense: true,),
               if(Constants.shouldShowDonation) ListTile(title: const Text("Donate"), leading: const Icon(Icons.celebration), onTap: () {Navigator.pushNamed(context, '/donate');}, dense: true,),
             ],

--- a/lib/openai_service.dart
+++ b/lib/openai_service.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:avaremp/storage.dart';
+import 'package:http/http.dart' as http;
+
+class OpenAIService {
+
+  final String apiKey;
+  final String model;
+
+  OpenAIService(this.apiKey, this.model);
+
+  static OpenAIService fromSettings() {
+    final String key = Storage().settings.getOpenAIKey();
+    final String model = Storage().settings.getOpenAIModel();
+    return OpenAIService(key, model);
+  }
+
+  Future<String> chat(List<Map<String, String>> messages) async {
+    if (apiKey.isEmpty) {
+      throw Exception("OpenAI API key is not set");
+    }
+    final Uri uri = Uri.parse('https://api.openai.com/v1/chat/completions');
+    final Map<String, dynamic> body = {
+      'model': model,
+      'messages': messages,
+      'temperature': 0.7,
+    };
+    final http.Response resp = await http
+        .post(
+          uri,
+          headers: {
+            'Authorization': 'Bearer $apiKey',
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode(body),
+        )
+        .timeout(const Duration(seconds: 60));
+
+    if (resp.statusCode < 200 || resp.statusCode >= 300) {
+      try {
+        final Map<String, dynamic> data = jsonDecode(resp.body) as Map<String, dynamic>;
+        final String message = (data['error']?['message'] ?? resp.reasonPhrase ?? 'Unknown error').toString();
+        throw Exception(message);
+      } catch (_) {
+        throw Exception('HTTP ${resp.statusCode}: ${resp.reasonPhrase}');
+      }
+    }
+
+    final Map<String, dynamic> data = jsonDecode(resp.body) as Map<String, dynamic>;
+    final List<dynamic> choices = data['choices'] as List<dynamic>;
+    if (choices.isEmpty) {
+      return '';
+    }
+    final Map<String, dynamic> message = choices.first['message'] as Map<String, dynamic>;
+    return (message['content'] ?? '').toString();
+  }
+}
+


### PR DESCRIPTION
Add a new AI chat screen with OpenAI integration and API key settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca23a5d3-b911-4866-8f4b-bd8af59eba06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca23a5d3-b911-4866-8f4b-bd8af59eba06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an AI Chat screen backed by OpenAI Chat Completions, with API key/model settings and new navigation route.
> 
> - **UI**:
>   - **New `ChatScreen`** (`lib/chat_screen.dart`): chat UI with message list, input, send/progress states, error display, and in-dialog settings.
> - **Service**:
>   - **`OpenAIService`** (`lib/openai_service.dart`): posts to `v1/chat/completions` using stored API key/model; parses response and errors.
> - **Settings**:
>   - `AppSettings`: add `setOpenAIKey/getOpenAIKey`, `setOpenAIModel/getOpenAIModel` (default model `gpt-4o-mini`).
> - **Navigation**:
>   - Register route `'/chat'` in `lib/main.dart`.
>   - Add drawer item "AI Chat" in `lib/main_screen.dart`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b553187cf84348311d98039cc41f129198b911bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->