### PR TITLE
Add example query dropdown to chatgpt screen

### DIFF
--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -271,4 +271,29 @@ class AppSettings {
     return provider.getValue("key-openai-userdb-file-id", defaultValue: "") as String;
   }
 
+  // Assistants + Vector Store IDs
+  void setOpenAiAssistantId(String assistantId) {
+    provider.setString("key-openai-assistant-id", assistantId);
+  }
+
+  String getOpenAiAssistantId() {
+    return provider.getValue("key-openai-assistant-id", defaultValue: "") as String;
+  }
+
+  void setOpenAiVectorStoreId(String vectorStoreId) {
+    provider.setString("key-openai-vector-store-id", vectorStoreId);
+  }
+
+  String getOpenAiVectorStoreId() {
+    return provider.getValue("key-openai-vector-store-id", defaultValue: "") as String;
+  }
+
+  void setOpenAiThreadId(String threadId) {
+    provider.setString("key-openai-thread-id", threadId);
+  }
+
+  String getOpenAiThreadId() {
+    return provider.getValue("key-openai-thread-id", defaultValue: "") as String;
+  }
+
 }

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -262,4 +262,13 @@ class AppSettings {
     return provider.getValue("key-openai-api-key", defaultValue: "") as String;
   }
 
+  // OpenAI uploaded user.db file id storage
+  void setOpenAiUserDbFileId(String fileId) {
+    provider.setString("key-openai-userdb-file-id", fileId);
+  }
+
+  String getOpenAiUserDbFileId() {
+    return provider.getValue("key-openai-userdb-file-id", defaultValue: "") as String;
+  }
+
 }

--- a/lib/chatgpt_screen.dart
+++ b/lib/chatgpt_screen.dart
@@ -52,6 +52,25 @@ class _ChatGptScreenState extends State<ChatGptScreen> {
   ];
   String? _categoryContext; // last loaded summary for selected category
   String? _categoryError;
+  // Example queries per category
+  final Map<String, List<String>> _exampleQueries = {
+    'Logbook': [
+      'Summarize my recent flight time by category.',
+      'How many night landings in the last 90 days?',
+      'What’s my total PIC time this year?',
+    ],
+    'Flight plan': [
+      'Suggest fuel stops for my current route.',
+      'Estimate flight time with current winds.',
+      'Identify potential alternates along the route.',
+    ],
+    'Aircraft': [
+      'Which aircraft do I fly most often?',
+      'Summarize key performance numbers for my aircraft.',
+      'What’s my recent time in this aircraft?',
+    ],
+  };
+  String? _selectedExample;
 
   @override
   void initState() {
@@ -217,6 +236,7 @@ class _ChatGptScreenState extends State<ChatGptScreen> {
   }
 
   Widget _buildCategorySelector() {
+    final List<String> examples = _exampleQueries[_selectedCategory] ?? const [];
     return Row(
       children: [
         const Text('Category:'),
@@ -230,10 +250,40 @@ class _ChatGptScreenState extends State<ChatGptScreen> {
             if (val == null) return;
             setState(() {
               _selectedCategory = val;
+              _selectedExample = null; // reset example when category changes
             });
             await _loadCategoryContext();
           },
         ),
+        const SizedBox(width: 16),
+        if (examples.isNotEmpty) ...[
+          const Text('Example:'),
+          const SizedBox(width: 8),
+          Flexible(
+            child: DropdownButton<String>(
+              isExpanded: true,
+              value: _selectedExample,
+              hint: const Text('Choose example'),
+              items: examples
+                  .map((q) => DropdownMenuItem<String>(
+                        value: q,
+                        child: Text(q, overflow: TextOverflow.ellipsis),
+                      ))
+                  .toList(),
+              onChanged: (val) {
+                if (val == null) return;
+                setState(() {
+                  _selectedExample = val;
+                });
+                _inputController.text = val;
+                _inputController.selection = TextSelection.fromPosition(
+                  TextPosition(offset: _inputController.text.length),
+                );
+                _inputFocusNode.requestFocus();
+              },
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/chatgpt_screen.dart
+++ b/lib/chatgpt_screen.dart
@@ -139,22 +139,19 @@ class _ChatGptScreenState extends State<ChatGptScreen> {
                     ],
                   })
               .toList();
-          // Attach file to the last user message
-          if (inputMessages.isNotEmpty && inputMessages.last['role'] == 'user') {
-            inputMessages.last['attachments'] = [
-              {
-                'file_id': fileId,
-                'tools': [
-                  {'type': 'file_search'}
-                ],
-              }
-            ];
-          }
 
           final Map<String, dynamic> payload = {
             'model': 'gpt-4.1-mini',
             'input': inputMessages,
             'max_output_tokens': 2000,
+            'tools': [
+              {'type': 'file_search'}
+            ],
+            'tool_resources': {
+              'file_search': {
+                'file_ids': [fileId]
+              }
+            }
           };
 
           final response = await http.post(

--- a/lib/chatgpt_screen.dart
+++ b/lib/chatgpt_screen.dart
@@ -147,11 +147,14 @@ class _ChatGptScreenState extends State<ChatGptScreen> {
             'tools': [
               {'type': 'file_search'}
             ],
-            'tool_resources': {
-              'file_search': {
-                'file_ids': [fileId]
+            'attachments': [
+              {
+                'file_id': fileId,
+                'tools': [
+                  {'type': 'file_search'}
+                ]
               }
-            }
+            ]
           };
 
           final response = await http.post(


### PR DESCRIPTION
Add an example queries dropdown next to the category dropdown on the ChatGPT screen.

This provides users with pre-defined query examples for each category, which are automatically placed into the query text box upon selection, improving usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-befc8484-99eb-4934-bbd0-25bc063e1ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-befc8484-99eb-4934-bbd0-25bc063e1ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

