### PR TITLE
Add antialiasing and increase flutter paint quality for plates

### DIFF
--- a/lib/plate_screen.dart
+++ b/lib/plate_screen.dart
@@ -421,7 +421,7 @@ class _PlatePainter extends CustomPainter {
   double? _variation;
 
   // Define a paint object
-  final _paint = Paint();
+  final _paint = Paint()
     ..isAntiAlias = true
     ..filterQuality = FilterQuality.high;
   // Define a paint object for circle


### PR DESCRIPTION
fixes #30 
Current plates render poorly. Proposed changes increase quality and add anti aliasing to sharpen lines.

E.g from KORD CSup on Windows (on same screen with same zoom)

Before:
<img width="958" height="694" alt="image" src="https://github.com/user-attachments/assets/1c254d4c-600a-4861-a2c4-9eb91dddd6a6" />

After:
<img width="976" height="699" alt="image" src="https://github.com/user-attachments/assets/423675c7-8c91-40af-89ca-90f75d9fd165" />