### PR TITLE
Kml tracks race condition

### DIFF
--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -1451,11 +1451,12 @@ class MapScreenState extends State<MapScreen> {
                                                     Expanded(flex: 2, child:Slider(min: 0, max: 1, divisions: 4, // levels of opacity, 0 is off
                                                     value: _layersOpacity[index],
                                                     onChanged: (double value) {
+                                                      final double previousOpacity = _layersOpacity[index];
                                                       setState1(() {
                                                         _layersOpacity[index] = value;
                                                       });
                                                       if(_layers[index] == "Tracks") {
-                                                        if(value == 0) {
+                                                        if(previousOpacity > 0 && value == 0) {
                                                           // save tracks on turning them off then show user where to get them
                                                           Storage().settings.setDocumentPage(DocumentsScreen.userDocuments);
                                                           Storage().tracks.saveKml().then((value) {
@@ -1469,8 +1470,8 @@ class MapScreenState extends State<MapScreen> {
                                                             });
                                                           });
                                                         }
-                                                        else {
-                                                          Storage().tracks = GpsRecorder(); //on turning on, start fresh
+                                                        else if(previousOpacity == 0 && value > 0) {
+                                                          Storage().tracks = GpsRecorder(); // on turning on, start fresh
                                                         }
                                                       }
                                                       if(_layers[index] == "OSM" && value > 0) {


### PR DESCRIPTION
Fixes KML tracks file being empty by correcting the logic for resetting and saving tracks when the layer opacity slider changes.

The previous implementation would reset `Storage().tracks` (clearing recorded points) on any non-zero slider change, including when dragging the slider towards zero. This caused the tracks to be cleared before `saveKml()` could execute, resulting in an empty KML file. The fix ensures tracks are only reset when the layer is turned *on* (0 -> >0 opacity) and saved when the layer is turned *off* (>0 -> 0 opacity).

---
<a href="https://cursor.com/background-agent?bcId=bc-69fe63e5-26f8-4f44-a1f5-1e5a8faa507f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69fe63e5-26f8-4f44-a1f5-1e5a8faa507f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

