### PR TITLE
Garmin flight plan transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ By Apps4Av.
 
 ## Getting Started
 
+## Garmin Connext Flight Plan Transfer (Android)
 
+1. Open the IO screen and connect to your Garmin device over Bluetooth.
+2. Go to Plan -> Actions -> Transfer.
+3. Tap "Send to Garmin" to transmit the current flight plan (NMEA RTE/WPL).
 
 ### Downloading
 

--- a/lib/io/garmin_connext.dart
+++ b/lib/io/garmin_connext.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:avaremp/destination/destination.dart';
+import 'package:avaremp/io/io_screen.dart';
+import 'package:avaremp/nmea/rte_packet.dart';
+import 'package:avaremp/nmea/wpl_packet.dart';
+import 'package:avaremp/plan/plan_route.dart';
+import 'package:avaremp/utils/app_log.dart';
+
+class GarminConnextTransfer {
+  static const Duration defaultSentenceDelay = Duration(milliseconds: 60);
+  static const int minWaypoints = 2;
+
+  static bool get isConnected =>
+      IoScreenState.connection?.isConnected ?? false;
+
+  static String? get connectedDeviceLabel {
+    final device = IoScreenState.connectedDevice;
+    if (device == null) {
+      return null;
+    }
+    final name = device.name ?? '';
+    if (name.isNotEmpty) {
+      return name;
+    }
+    return device.address;
+  }
+
+  static Future<String?> sendFlightPlan(PlanRoute route,
+      {Duration sentenceDelay = defaultSentenceDelay}) async {
+    if (!isConnected) {
+      return "No Bluetooth connection. Pair a Garmin device in IO.";
+    }
+
+    final destinations = route.getAllDestinations();
+    if (destinations.length < minWaypoints) {
+      return "Flight plan needs at least two waypoints.";
+    }
+
+    final connection = IoScreenState.connection;
+    if (connection == null || !connection.isConnected) {
+      return "Bluetooth connection lost.";
+    }
+
+    final messages = GarminConnextEncoder.buildFlightPlanMessages(route);
+    if (messages.isEmpty) {
+      return "Flight plan is empty.";
+    }
+
+    IoScreenState.transferInProgress = true;
+    try {
+      for (final message in messages) {
+        if (!connection.isConnected) {
+          return "Bluetooth connection lost.";
+        }
+        connection.output.add(utf8.encode(message));
+        await connection.output.allSent;
+        if (sentenceDelay > Duration.zero) {
+          await Future.delayed(sentenceDelay);
+        }
+      }
+    } catch (e) {
+      AppLog.logMessage("Garmin Connext transfer failed: $e");
+      return "Failed to send flight plan.";
+    } finally {
+      IoScreenState.transferInProgress = false;
+    }
+
+    return null;
+  }
+}
+
+/// Builds Garmin Connext flight plan transfer messages using NMEA RTE/WPL.
+class GarminConnextEncoder {
+  static const int maxWaypointNameLength = 6;
+  static const int maxRouteNameLength = 8;
+  static const int maxWaypointsPerSentence = 7;
+
+  static List<String> buildFlightPlanMessages(PlanRoute route) {
+    final destinations = route.getAllDestinations();
+    if (destinations.isEmpty) {
+      return [];
+    }
+
+    final routeName = _sanitizeRouteName(route.name);
+    final waypointNames = _buildWaypointNames(destinations);
+
+    final messages = <String>[];
+    final sentWaypoints = <String>{};
+    for (int index = 0; index < destinations.length; index++) {
+      final name = waypointNames[index];
+      if (sentWaypoints.add(name)) {
+        final destination = destinations[index];
+        final packet = WPLPacket(
+          destination.coordinate.latitude,
+          destination.coordinate.longitude,
+          name,
+        );
+        messages.add(packet.getPacket());
+      }
+    }
+
+    final segments = _chunkWaypoints(waypointNames);
+    final total = segments.length;
+    for (int index = 0; index < segments.length; index++) {
+      final packet = RTEPacket(
+        totalSentences: total,
+        sentenceNumber: index + 1,
+        isComplete: true,
+        routeName: routeName,
+        waypoints: segments[index],
+      );
+      messages.add(packet.getPacket());
+    }
+
+    return messages;
+  }
+
+  static List<String> _buildWaypointNames(List<Destination> destinations) {
+    final usedNames = <String>{};
+    final names = <String>[];
+    for (int index = 0; index < destinations.length; index++) {
+      final destination = destinations[index];
+      final base = _sanitizeBaseName(destination.locationID);
+      final name = _makeUniqueName(base, usedNames);
+      names.add(name);
+    }
+    return names;
+  }
+
+  static String _sanitizeRouteName(String name) {
+    final cleaned = _sanitizeBaseName(name);
+    if (cleaned.isEmpty) {
+      return "AVARE";
+    }
+    return _truncate(cleaned, maxRouteNameLength);
+  }
+
+  static String _sanitizeBaseName(String raw) {
+    return raw
+        .toUpperCase()
+        .replaceAll(RegExp(r'[^A-Z0-9]'), '');
+  }
+
+  static String _makeUniqueName(String base, Set<String> used) {
+    String cleaned = base.isEmpty ? 'WP' : base;
+    String candidate = _truncate(cleaned, maxWaypointNameLength);
+    int suffix = 1;
+    while (used.contains(candidate)) {
+      final suffixText = suffix.toString();
+      final available = maxWaypointNameLength - suffixText.length;
+      final prefix = _truncate(cleaned, available < 1 ? 1 : available);
+      candidate = '$prefix$suffixText';
+      suffix++;
+    }
+    used.add(candidate);
+    return candidate;
+  }
+
+  static String _truncate(String value, int maxLength) {
+    if (value.length <= maxLength) {
+      return value;
+    }
+    return value.substring(0, maxLength);
+  }
+
+  static List<List<String>> _chunkWaypoints(List<String> waypoints) {
+    final segments = <List<String>>[];
+    int index = 0;
+    while (index < waypoints.length) {
+      final end = (index + maxWaypointsPerSentence) > waypoints.length
+          ? waypoints.length
+          : index + maxWaypointsPerSentence;
+      segments.add(waypoints.sublist(index, end));
+      index = end;
+    }
+    return segments;
+  }
+}

--- a/lib/io/io_screen.dart
+++ b/lib/io/io_screen.dart
@@ -20,11 +20,15 @@ class IoScreenState extends State<IoScreen> {
   bool isDiscovering = false;
   static BluetoothConnection? connection;
   static BluetoothDevice? connectedDevice;// this should stay in memory, not putting in storage as this is platform specific
+  static bool transferInProgress = false;
 
 
   // send data to remote
   static void sendData(String data) async {
     // this sends autopilot data
+    if(transferInProgress) {
+      return;
+    }
     if(connection == null || (!connection!.isConnected)) {
       return;
     }

--- a/lib/nmea/rte_packet.dart
+++ b/lib/nmea/rte_packet.dart
@@ -1,0 +1,25 @@
+import 'package:avaremp/nmea/packet.dart';
+
+class RTEPacket extends Packet {
+  static const String _tag = '\$GPRTE';
+
+  RTEPacket({
+    required int totalSentences,
+    required int sentenceNumber,
+    required bool isComplete,
+    required String routeName,
+    required List<String> waypoints,
+  }) {
+    packet = '$_tag,';
+    packet += '$totalSentences,';
+    packet += '$sentenceNumber,';
+    packet += isComplete ? 'c' : 'w';
+    packet += ',';
+    packet += routeName;
+    for (final waypoint in waypoints) {
+      packet += ',';
+      packet += waypoint;
+    }
+    assemble();
+  }
+}

--- a/lib/nmea/wpl_packet.dart
+++ b/lib/nmea/wpl_packet.dart
@@ -1,0 +1,33 @@
+import 'package:avaremp/nmea/packet.dart';
+
+class WPLPacket extends Packet {
+  static const String _tag = '\$GPWPL';
+
+  WPLPacket(double latitude, double longitude, String waypointName) {
+    packet = '$_tag,';
+    packet += _formatLat(latitude);
+    packet += ',';
+    packet += _formatLon(longitude);
+    packet += ',';
+    packet += waypointName;
+    assemble();
+  }
+
+  static String _formatLat(double latitude) {
+    final String hemisphere = latitude >= 0 ? 'N' : 'S';
+    final double value = latitude.abs();
+    final int degrees = value.floor();
+    final double minutes = (value - degrees) * 60.0;
+    final String minutesText = minutes.toStringAsFixed(4).padLeft(7, '0');
+    return '${degrees.toString().padLeft(2, '0')}$minutesText,$hemisphere';
+  }
+
+  static String _formatLon(double longitude) {
+    final String hemisphere = longitude >= 0 ? 'E' : 'W';
+    final double value = longitude.abs();
+    final int degrees = value.floor();
+    final double minutes = (value - degrees) * 60.0;
+    final String minutesText = minutes.toStringAsFixed(4).padLeft(7, '0');
+    return '${degrees.toString().padLeft(3, '0')}$minutesText,$hemisphere';
+  }
+}

--- a/lib/plan/plan_action_screen.dart
+++ b/lib/plan/plan_action_screen.dart
@@ -1,7 +1,9 @@
+import 'package:avaremp/constants.dart';
 import 'package:avaremp/plan/plan_create_widget.dart';
 import 'package:avaremp/plan/plan_file_widget.dart';
 import 'package:avaremp/plan/plan_load_save_widget.dart';
 import 'package:avaremp/plan/plan_manage_widget.dart';
+import 'package:avaremp/plan/plan_transfer_widget.dart';
 import 'package:flutter/material.dart';
 
 class PlanActionScreen extends StatefulWidget {
@@ -26,19 +28,8 @@ class PlanActionState extends State<PlanActionScreen> {
 
   Widget _makeContent() {
 
-    Widget loadSavePage = const PlanLoadSaveWidget();
-
-    Widget createPage = const PlanCreateWidget();
-
-    Widget filePage = const PlanFileWidget();
-
-    Widget managePage = const PlanManageWidget();
-
-    List<Widget> pages = [];
-    pages.add(loadSavePage);
-    pages.add(createPage);
-    pages.add(filePage);
-    pages.add(managePage);
+    final tabs = _buildTabs();
+    final current = _current >= tabs.length ? 0 : _current;
 
     return Container(
         padding: const EdgeInsets.all(5),
@@ -51,38 +42,41 @@ class PlanActionState extends State<PlanActionScreen> {
         child:
         Column(children: [
           // various info
-          Expanded(flex: 8, child: Padding(padding: const EdgeInsets.all(10), child: pages[_current])),
+          Expanded(
+              flex: 8,
+              child: Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: tabs[current].page)),
           // add various buttons that expand to diagram
           Expanded(flex: 1, child: SingleChildScrollView(scrollDirection: Axis.horizontal, child: Row(mainAxisAlignment: MainAxisAlignment.end, children:[
-            TextButton(
-                child: const Text("Load & Save"),
-                onPressed: () => setState(() {
-                  _current = 0;
-                })
-            ),
-            TextButton(
-                child: const Text("Create"),
-                onPressed: () => setState(() {
-                  _current = 1;
-                })
-            ),
-            TextButton(
-                child: const Text("Brief & File"),
-                onPressed: () => setState(() {
-                  _current = 2;
-                })
-            ),
-            TextButton(
-                child: const Text("Manage"),
-                onPressed: () => setState(() {
-                  _current = 3;
-                })
-            ),
+            for (int index = 0; index < tabs.length; index++)
+              TextButton(
+                  child: Text(tabs[index].label),
+                  onPressed: () => setState(() {
+                        _current = index;
+                      }))
           ])),
           ),
         ],
         )
     );
+  }
+
+  List<_PlanActionTab> _buildTabs() {
+    final tabs = <_PlanActionTab>[
+      _PlanActionTab(
+          label: "Load & Save", page: const PlanLoadSaveWidget()),
+      _PlanActionTab(label: "Create", page: const PlanCreateWidget()),
+      _PlanActionTab(label: "Brief & File", page: const PlanFileWidget()),
+      _PlanActionTab(label: "Manage", page: const PlanManageWidget()),
+    ];
+
+    if (Constants.shouldShowBluetoothSpp) {
+      tabs.add(_PlanActionTab(
+          label: "Transfer", page: const PlanTransferWidget()));
+    }
+
+    return tabs;
   }
 
 
@@ -94,4 +88,11 @@ class PlanActionState extends State<PlanActionScreen> {
     ),
     body: _makeContent());
   }
+}
+
+class _PlanActionTab {
+  final String label;
+  final Widget page;
+
+  const _PlanActionTab({required this.label, required this.page});
 }

--- a/lib/plan/plan_transfer_widget.dart
+++ b/lib/plan/plan_transfer_widget.dart
@@ -1,0 +1,135 @@
+import 'package:avaremp/constants.dart';
+import 'package:avaremp/io/garmin_connext.dart';
+import 'package:avaremp/storage.dart';
+import 'package:avaremp/utils/toast.dart';
+import 'package:flutter/material.dart';
+
+class PlanTransferWidget extends StatefulWidget {
+  const PlanTransferWidget({super.key});
+
+  @override
+  State<StatefulWidget> createState() => PlanTransferWidgetState();
+}
+
+class PlanTransferWidgetState extends State<PlanTransferWidget> {
+  bool _sending = false;
+  String _status = "";
+  Color _statusColor = Colors.green;
+
+  Future<void> _openBluetooth() async {
+    await Navigator.pushNamed(context, '/io');
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> _sendToGarmin() async {
+    setState(() {
+      _sending = true;
+      _status = "";
+    });
+
+    final error = await GarminConnextTransfer.sendFlightPlan(Storage().route);
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _sending = false;
+      if (error == null) {
+        final device = GarminConnextTransfer.connectedDeviceLabel ?? "Garmin device";
+        _status = "Flight plan sent to $device.";
+        _statusColor = Colors.green;
+      } else {
+        _status = error;
+        _statusColor = Colors.red;
+      }
+    });
+
+    if (error == null) {
+      Toast.showToast(context, "Sent flight plan to Garmin device",
+          const Icon(Icons.check, color: Colors.green), 3);
+    } else {
+      Toast.showToast(context, error,
+          const Icon(Icons.error, color: Colors.red), 4);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final route = Storage().route;
+    final destinations = route.getAllDestinations();
+    final bool isConnected = GarminConnextTransfer.isConnected;
+    final String connectionLabel =
+        GarminConnextTransfer.connectedDeviceLabel ?? "Not connected";
+    final bool canSend = isConnected &&
+        destinations.length >= GarminConnextTransfer.minWaypoints &&
+        !_sending;
+
+    return Container(
+        padding: const EdgeInsets.all(0),
+        child: Column(children: [
+          Expanded(
+              flex: 1,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  child: const Text("Transfer",
+                      style: TextStyle(fontWeight: FontWeight.w800)))),
+          Expanded(
+              flex: 2,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  alignment: Alignment.centerLeft,
+                  child: const Text(
+                      "Send the current flight plan to a Garmin device using Garmin Connext over Bluetooth."))),
+          Expanded(
+              flex: 1,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  child: Row(children: [
+                    Icon(
+                        isConnected
+                            ? Icons.bluetooth_connected
+                            : Icons.bluetooth_disabled,
+                        color: isConnected ? Colors.green : Colors.red),
+                    const Padding(padding: EdgeInsets.all(6)),
+                    Expanded(child: Text(connectionLabel)),
+                  ]))),
+          Expanded(
+              flex: 1,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                      "Plan: ${route.name} (${destinations.length} waypoints)"))),
+          Expanded(
+              flex: 2,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  child: Row(children: [
+                    if (Constants.shouldShowBluetoothSpp)
+                      TextButton(
+                          onPressed: _openBluetooth,
+                          child: const Text("Open Bluetooth")),
+                    const Padding(padding: EdgeInsets.fromLTRB(6, 0, 6, 0)),
+                    TextButton(
+                        onPressed: canSend ? _sendToGarmin : null,
+                        child: const Text("Send to Garmin")),
+                    const Padding(padding: EdgeInsets.fromLTRB(10, 0, 0, 0)),
+                    SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: Visibility(
+                            visible: _sending,
+                            child: const CircularProgressIndicator())),
+                  ]))),
+          Expanded(
+              flex: 1,
+              child: Container(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                  alignment: Alignment.centerLeft,
+                  child: Text(_status,
+                      style: TextStyle(color: _statusColor)))),
+        ]));
+  }
+}


### PR DESCRIPTION
Add Garmin Connext flight plan transfer support for Garmin devices.

This PR implements the ability to transfer flight plans to Garmin devices using the Garmin Connext protocol, specifically NMEA RTE/WPL sentences over Bluetooth. A new "Transfer" tab has been added to the Plan Actions screen for initiating these transfers, and the Bluetooth output is paused during the transfer process to ensure data integrity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5818011f-35f4-430d-b847-957a0f6d0f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5818011f-35f4-430d-b847-957a0f6d0f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

