### PR TITLE
Avidyne flight plan transfer

### DIFF
--- a/lib/nmea/rte_packet.dart
+++ b/lib/nmea/rte_packet.dart
@@ -1,0 +1,11 @@
+import 'package:avaremp/nmea/packet.dart';
+
+class RTEPacket extends Packet {
+  RTEPacket(int totalSentences, int sentenceNumber, String routeId, List<String> waypoints) {
+    packet = '\$GPRTE,$totalSentences,$sentenceNumber,c,$routeId';
+    for (final waypoint in waypoints) {
+      packet += ',$waypoint';
+    }
+    assemble();
+  }
+}

--- a/lib/nmea/wpl_packet.dart
+++ b/lib/nmea/wpl_packet.dart
@@ -1,0 +1,38 @@
+import 'package:avaremp/nmea/packet.dart';
+
+class WPLPacket extends Packet {
+  WPLPacket(double latitude, double longitude, String id) {
+    packet = '\$GPWPL,';
+
+    // Latitude in ddmm.mmm format
+    if (latitude >= 0) {
+      int lat = latitude.toInt();
+      double minutes = (latitude - lat) * 60.0;
+      packet += lat.toString().padLeft(2, '0');
+      packet += '${minutes.toStringAsFixed(3).padLeft(6, '0')},N,';
+    } else {
+      latitude = -latitude;
+      int lat = latitude.toInt();
+      double minutes = (latitude - lat) * 60.0;
+      packet += lat.toString().padLeft(2, '0');
+      packet += '${minutes.toStringAsFixed(3).padLeft(6, '0')},S,';
+    }
+
+    // Longitude in dddmm.mmm format
+    if (longitude >= 0) {
+      int lon = longitude.toInt();
+      double minutes = (longitude - lon) * 60.0;
+      packet += lon.toString().padLeft(3, '0');
+      packet += '${minutes.toStringAsFixed(3).padLeft(6, '0')},E,';
+    } else {
+      longitude = -longitude;
+      int lon = longitude.toInt();
+      double minutes = (longitude - lon) * 60.0;
+      packet += lon.toString().padLeft(3, '0');
+      packet += '${minutes.toStringAsFixed(3).padLeft(6, '0')},W,';
+    }
+
+    packet += id;
+    assemble();
+  }
+}

--- a/lib/plan/avidyne_transfer.dart
+++ b/lib/plan/avidyne_transfer.dart
@@ -1,0 +1,191 @@
+import 'package:avaremp/destination/destination.dart';
+import 'package:avaremp/nmea/rte_packet.dart';
+import 'package:avaremp/nmea/wpl_packet.dart';
+import 'package:avaremp/plan/plan_route.dart';
+import 'package:latlong2/latlong.dart';
+
+class AvidyneTransferPayload {
+  final String data;
+  final int waypointCount;
+  final int userWaypointCount;
+  final int sentenceCount;
+  final String routeId;
+
+  const AvidyneTransferPayload({
+    required this.data,
+    required this.waypointCount,
+    required this.userWaypointCount,
+    required this.sentenceCount,
+    required this.routeId,
+  });
+}
+
+class AvidyneTransfer {
+  static const int _maxWaypointIdLength = 6;
+  static const int _maxNmeaSentenceLength = 82;
+  static const String _defaultRouteId = 'AVX';
+
+  static AvidyneTransferPayload? buildTransfer(PlanRoute route) {
+    final destinations = route.getAllDestinations();
+    if (destinations.isEmpty) {
+      return null;
+    }
+
+    final _PreparedWaypoints prepared = _prepareWaypoints(destinations);
+    final String routeId = _sanitizeRouteId(route.name);
+    final List<String> wplSentences = prepared.waypoints
+        .map((waypoint) => WPLPacket(
+          waypoint.coordinate.latitude,
+          waypoint.coordinate.longitude,
+          waypoint.id,
+        ).packet)
+        .toList();
+    final List<String> rteSentences = _buildRteSentences(prepared.routeIds, routeId);
+    final String data = (wplSentences + rteSentences).join();
+
+    return AvidyneTransferPayload(
+      data: data,
+      waypointCount: prepared.waypoints.length,
+      userWaypointCount: prepared.userWaypointCount,
+      sentenceCount: wplSentences.length + rteSentences.length,
+      routeId: routeId,
+    );
+  }
+
+  static _PreparedWaypoints _prepareWaypoints(List<Destination> destinations) {
+    final List<_AvidyneWaypoint> waypoints = [];
+    final List<String> routeIds = [];
+    final Map<String, String> idToCoordinate = {};
+    int userWaypointCount = 0;
+    int userIndex = 1;
+
+    for (final destination in destinations) {
+      final String coordKey = _coordinateKey(destination.coordinate);
+      String id = _baseWaypointId(destination);
+      bool isUser = id.isEmpty;
+
+      if (id.isNotEmpty && idToCoordinate.containsKey(id)) {
+        if (idToCoordinate[id] != coordKey) {
+          id = '';
+          isUser = true;
+        }
+      }
+
+      if (id.isEmpty) {
+        id = _makeUserId(userIndex++);
+        isUser = true;
+      }
+
+      idToCoordinate[id] = coordKey;
+      routeIds.add(id);
+      waypoints.add(_AvidyneWaypoint(id: id, coordinate: destination.coordinate));
+      if (isUser) {
+        userWaypointCount++;
+      }
+    }
+
+    return _PreparedWaypoints(
+      waypoints: waypoints,
+      routeIds: routeIds,
+      userWaypointCount: userWaypointCount,
+    );
+  }
+
+  static List<String> _buildRteSentences(List<String> waypointIds, String routeId) {
+    if (waypointIds.isEmpty) {
+      return [];
+    }
+
+    final List<List<String>> chunks = [];
+    final String base = '\$GPRTE,99,99,c,$routeId';
+    final int baseLength = base.length;
+
+    List<String> current = [];
+    int currentLength = baseLength;
+
+    for (final id in waypointIds) {
+      final int addedLength = 1 + id.length; // comma + waypoint id
+      if (current.isNotEmpty &&
+          (currentLength + addedLength + 5) > _maxNmeaSentenceLength) {
+        chunks.add(current);
+        current = [];
+        currentLength = baseLength;
+      }
+      current.add(id);
+      currentLength += addedLength;
+    }
+
+    if (current.isNotEmpty) {
+      chunks.add(current);
+    }
+
+    final int total = chunks.length;
+    return List<String>.generate(total, (index) {
+      return RTEPacket(total, index + 1, routeId, chunks[index]).packet;
+    });
+  }
+
+  static String _sanitizeRouteId(String name) {
+    final String cleaned = _sanitizeId(name);
+    if (cleaned.isEmpty) {
+      return _defaultRouteId;
+    }
+    return cleaned.substring(0, cleaned.length > _maxWaypointIdLength ? _maxWaypointIdLength : cleaned.length);
+  }
+
+  static String _baseWaypointId(Destination destination) {
+    if (destination.type == Destination.typeGps) {
+      return '';
+    }
+    final bool isComposite = Destination.isAirway(destination.type) || Destination.isProcedure(destination.type);
+    final String? secondary = destination.secondaryName;
+    if (isComposite && (secondary == null || secondary.trim().isEmpty)) {
+      return '';
+    }
+    final String rawId = (secondary != null && secondary.trim().isNotEmpty)
+        ? secondary
+        : destination.locationID;
+    final String cleaned = _sanitizeId(rawId);
+    if (cleaned.isEmpty || cleaned.length > _maxWaypointIdLength) {
+      return '';
+    }
+    return cleaned;
+  }
+
+  static String _sanitizeId(String value) {
+    return value
+        .trim()
+        .toUpperCase()
+        .replaceAll(RegExp(r'[^A-Z0-9]'), '');
+  }
+
+  static String _makeUserId(int index) {
+    if (index > 9999) {
+      return 'WP9999';
+    }
+    return 'WP${index.toString().padLeft(4, '0')}';
+  }
+
+  static String _coordinateKey(LatLng coordinate) {
+    return '${coordinate.latitude.toStringAsFixed(6)},${coordinate.longitude.toStringAsFixed(6)}';
+  }
+}
+
+class _AvidyneWaypoint {
+  final String id;
+  final LatLng coordinate;
+
+  _AvidyneWaypoint({required this.id, required this.coordinate});
+}
+
+class _PreparedWaypoints {
+  final List<_AvidyneWaypoint> waypoints;
+  final List<String> routeIds;
+  final int userWaypointCount;
+
+  _PreparedWaypoints({
+    required this.waypoints,
+    required this.routeIds,
+    required this.userWaypointCount,
+  });
+}

--- a/lib/plan/plan_action_screen.dart
+++ b/lib/plan/plan_action_screen.dart
@@ -2,6 +2,7 @@ import 'package:avaremp/plan/plan_create_widget.dart';
 import 'package:avaremp/plan/plan_file_widget.dart';
 import 'package:avaremp/plan/plan_load_save_widget.dart';
 import 'package:avaremp/plan/plan_manage_widget.dart';
+import 'package:avaremp/plan/plan_transfer_widget.dart';
 import 'package:flutter/material.dart';
 
 class PlanActionScreen extends StatefulWidget {
@@ -33,12 +34,14 @@ class PlanActionState extends State<PlanActionScreen> {
     Widget filePage = const PlanFileWidget();
 
     Widget managePage = const PlanManageWidget();
+    Widget transferPage = const PlanTransferWidget();
 
     List<Widget> pages = [];
     pages.add(loadSavePage);
     pages.add(createPage);
     pages.add(filePage);
     pages.add(managePage);
+    pages.add(transferPage);
 
     return Container(
         padding: const EdgeInsets.all(5),
@@ -76,6 +79,12 @@ class PlanActionState extends State<PlanActionScreen> {
                 child: const Text("Manage"),
                 onPressed: () => setState(() {
                   _current = 3;
+                })
+            ),
+            TextButton(
+                child: const Text("Transfer"),
+                onPressed: () => setState(() {
+                  _current = 4;
                 })
             ),
           ])),

--- a/lib/plan/plan_transfer_widget.dart
+++ b/lib/plan/plan_transfer_widget.dart
@@ -1,0 +1,116 @@
+import 'package:avaremp/constants.dart';
+import 'package:avaremp/io/io_screen.dart';
+import 'package:avaremp/plan/avidyne_transfer.dart';
+import 'package:avaremp/storage.dart';
+import 'package:avaremp/utils/toast.dart';
+import 'package:flutter/material.dart';
+
+class PlanTransferWidget extends StatefulWidget {
+  const PlanTransferWidget({super.key});
+
+  @override
+  State<StatefulWidget> createState() => PlanTransferWidgetState();
+}
+
+class PlanTransferWidgetState extends State<PlanTransferWidget> {
+  bool _sending = false;
+  String _status = '';
+  Color? _statusColor;
+
+  Future<void> _sendPlan(AvidyneTransferPayload payload) async {
+    if (!Constants.shouldShowBluetoothSpp) {
+      Toast.showToast(context, "Bluetooth transfer is available on Android only.", null, 3);
+      return;
+    }
+    if (!IoScreenState.isConnected) {
+      Toast.showToast(context, "Connect to your Avidyne device in IO first.", null, 3);
+      return;
+    }
+    setState(() {
+      _sending = true;
+      _status = '';
+      _statusColor = null;
+    });
+
+    bool ok = await IoScreenState.sendPlanData(payload.data);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _sending = false;
+      if (ok) {
+        _status = "Transfer complete (${payload.waypointCount} waypoints).";
+        if (payload.userWaypointCount > 0) {
+          _status += " ${payload.userWaypointCount} user waypoints created.";
+        }
+        _statusColor = Colors.green;
+      } else {
+        _status = "Transfer failed. Check Bluetooth connection.";
+        _statusColor = Colors.red;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: Storage().route.change,
+      builder: (context, value, child) {
+        final AvidyneTransferPayload? payload = AvidyneTransfer.buildTransfer(Storage().route);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text("Transfer (Avidyne)", style: TextStyle(fontWeight: FontWeight.w800)),
+            const Padding(padding: EdgeInsets.all(6)),
+            const Text("Send the current flight plan to Avidyne equipment using Bluetooth."),
+            const Padding(padding: EdgeInsets.all(6)),
+            Row(
+              children: [
+                Icon(
+                  IoScreenState.isConnected ? Icons.bluetooth_connected : Icons.bluetooth_disabled,
+                  color: IoScreenState.isConnected ? Colors.green : Colors.grey,
+                ),
+                const Padding(padding: EdgeInsets.fromLTRB(6, 0, 0, 0)),
+                Expanded(
+                  child: Text(
+                    IoScreenState.isConnected
+                        ? "Connected to ${IoScreenState.connectionName ?? "device"}"
+                        : "Not connected",
+                  ),
+                ),
+              ],
+            ),
+            const Padding(padding: EdgeInsets.all(6)),
+            if (!Constants.shouldShowBluetoothSpp)
+              const Text("Bluetooth transfer is not available on this platform."),
+            if (payload == null)
+              const Text("No flight plan to transfer."),
+            if (payload != null) ...[
+              Text("Route ID: ${payload.routeId}"),
+              Text("Waypoints: ${payload.waypointCount}"),
+              if (payload.userWaypointCount > 0)
+                Text("User waypoints: ${payload.userWaypointCount}"),
+              Text("NMEA sentences: ${payload.sentenceCount}"),
+              const Padding(padding: EdgeInsets.all(6)),
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: _sending ? null : () => _sendPlan(payload),
+                    child: const Text("Send to Avidyne"),
+                  ),
+                  const Padding(padding: EdgeInsets.fromLTRB(10, 0, 0, 0)),
+                  if (_sending) const SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
+                ],
+              ),
+              if (_status.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 6, 0, 0),
+                  child: Text(_status, style: TextStyle(color: _statusColor)),
+                ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Add flight plan transfer functionality to Avidyne equipment via Bluetooth.

This allows users to send their current flight plan to compatible Avidyne devices, generating NMEA WPL/RTE sentences and temporarily pausing other NMEA output during transfer to prevent interleaved streams.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-437c0c20-2bd1-475d-9f90-ce7fe5ad2b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-437c0c20-2bd1-475d-9f90-ce7fe5ad2b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

