### PR TITLE
Added number pad to writing screen.

### DIFF
--- a/lib/writing_screen.dart
+++ b/lib/writing_screen.dart
@@ -19,6 +19,8 @@ class WritingScreen extends StatefulWidget {
 
 class WritingScreenState extends State<WritingScreen> {
   late ScribbleNotifier notifier;
+  final ValueNotifier<bool> _showNumberPad = ValueNotifier(false);
+  final ValueNotifier<String> _enteredNumbers = ValueNotifier("");
 
   @override
   void initState() {
@@ -29,6 +31,9 @@ class WritingScreenState extends State<WritingScreen> {
   @override
   void dispose() {
     UserDatabaseHelper.db.saveSketch("Default", jsonEncode(notifier.currentSketch.toJson()));
+    // remove data entered via number pad
+    _showNumberPad.dispose();
+    _enteredNumbers.dispose();
     super.dispose();
   }
 
@@ -59,7 +64,66 @@ class WritingScreenState extends State<WritingScreen> {
                   Container(color: Theme.of(context).brightness == Brightness.light ? Colors.white: Colors.black, child:
                   Scribble(notifier: notifier, drawPen: false, drawEraser: false)
                   ),
+                  // overlay for displaying numbers entered via number pad
+                  ValueListenableBuilder<String>(
+                    valueListenable: _enteredNumbers,
+                    builder: (context, text, child) {
+                      if (text.isEmpty) return const SizedBox();
+                      final lines = text.split('\n');
+                      return Positioned(
+                        top: 20,
+                        left: 0,
+                        right: 0,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: lines.asMap().entries.map((entry) {
+                            final index = entry.key;
+                            final line = entry.value;
+                            return ValueListenableBuilder(
+                              valueListenable: notifier,
+                              builder: (context, state, child) {
+                                Color color = Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white;
+                                return IgnorePointer(
+                                  ignoring: state is! Erasing,
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
+                                    onTap: () {
+                                      // Remove specific line if eraser is active
+                                      final currentLines = _enteredNumbers.value.split('\n');
+                                      if (index < currentLines.length) {
+                                        currentLines.removeAt(index);
+                                        _enteredNumbers.value = currentLines.join('\n');
+                                      }
+                                    },
+                                    child: Center(
+                                      child: Text(
+                                        line.isEmpty ? " " : line,
+                                        textAlign: TextAlign.center,
+                                        style: TextStyle(
+                                          fontSize: 50,
+                                          color: color,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              },
+                            );
+                          }).toList(),
+                        ),
+                      );
+                    },
+                  ),
                 ])
+                ),
+                // number pad UI section
+                ValueListenableBuilder<bool>(
+                  valueListenable: _showNumberPad,
+                  builder: (context, show, child) {
+                    if (!show) return const SizedBox();
+                    return _buildNumberPad(context);
+                  },
                 ),
                 Padding(
                   padding: const EdgeInsets.all(8),
@@ -96,7 +160,11 @@ class WritingScreenState extends State<WritingScreen> {
       IconButton(
         icon: Icon(MdiIcons.eraser),
         tooltip: "Clear",
-        onPressed: notifier.clear,
+        onPressed: () {
+          notifier.clear();
+          // clear number pad input when clearing the sketch
+          _enteredNumbers.value = "";
+        },
       ),
       IconButton(
           icon: const Icon(Icons.save),
@@ -118,11 +186,101 @@ class WritingScreenState extends State<WritingScreen> {
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
+        _buildNumberPadButton(context),
         _buildColorButton(context, color: Theme.of(context).brightness == Brightness.light ? Colors.black: Colors.white),
         _buildColorButton(context, color: Colors.red),
         _buildColorButton(context, color: Colors.green),
         _buildEraserButton(context),
       ],
+    );
+  }
+
+  // toggle button for number pad in toolbar
+  Widget _buildNumberPadButton(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _showNumberPad,
+      builder: (context, show, child) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: ColorButton(
+          color: Colors.transparent,
+          outlineColor: Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
+          isActive: show,
+          onPressed: () => _showNumberPad.value = !show,
+          child: Text(
+            "123",
+            style: TextStyle(
+              color: Theme.of(context).brightness == Brightness.light ? Colors.black : Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // layout of the number pad
+  Widget _buildNumberPad(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      decoration: BoxDecoration(
+        color: Theme.of(context).brightness == Brightness.light ? Colors.grey[200] : Colors.grey[900],
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var row in [
+            ["1", "2", "3"],
+            ["4", "5", "6"],
+            ["7", "8", "9"],
+            [".", "0", "⌫"],
+            ["ENTER"]
+          ])
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: row.map((e) => _buildKey(e)).toList(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  // individual keys for the number pad
+  Widget _buildKey(String label) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2.0),
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size.fromHeight(60),
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            side: BorderSide(
+              color: Theme.of(context).brightness == Brightness.light ? Colors.grey.shade400 : Colors.grey.shade700,
+            ),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+          ),
+          onPressed: () {
+            if (label == "⌫") {
+              if (_enteredNumbers.value.isNotEmpty) {
+                _enteredNumbers.value = _enteredNumbers.value.substring(0, _enteredNumbers.value.length - 1);
+              }
+            } else if (label == "ENTER") {
+              _enteredNumbers.value += "\n";
+            } else {
+              _enteredNumbers.value += label;
+            }
+          },
+          child: label == "ENTER"
+              ? const Icon(Icons.keyboard_return)
+              : Text(
+                  label,
+                  style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                ),
+        ),
+      ),
     );
   }
 
@@ -176,7 +334,7 @@ class ColorButton extends StatelessWidget {
 
   final VoidCallback onPressed;
 
-  final Icon? child;
+  final Widget? child;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
For Helicopter reasons, I can only take one hand off controls. Since I'm terrible at writing with my left hand, I have added a button to open a number pad on the scribble screen. This allows to enter squawk codes and frequencies provided by ATC, and be actually able to read it back.

Clear button will remove all data and the brush (?) symbol will remove line by line.