### PR TITLE
Migrate Flight Intelligence AI from Gemini 2.5 Pro to 3.6 Flash

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1030,7 +1030,7 @@ From MAP top-right account icon, or by routed requests from some features (e.g.,
 
 Screen title: **Flight Intelligence**
 
-Powered by Gemini 3.1 Pro with Google Search integration.
+Powered by Gemini 3.6 Flash with Google Search integration.
 
 Capabilities:
 
@@ -1953,7 +1953,7 @@ If the IFD has an ADS-B receiver, AvareX also picks up its **Capstone** ADS-B tr
 
 - Current Pro AI workflows are targeted for iOS/Android only.
 - Access from map account icon → Pro Services → Flight Intelligence.
-- Uses Gemini 3.1 Pro with Google Search integration.
+- Uses Gemini 3.6 Flash with Google Search integration.
 - Source threads:
   - AI feature thread:  
     `https://groups.google.com/g/apps4av-forum/c/wWZUn6TNG1w`

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1030,7 +1030,7 @@ From MAP top-right account icon, or by routed requests from some features (e.g.,
 
 Screen title: **Flight Intelligence**
 
-Powered by Gemini 2.5 Pro with Google Search integration.
+Powered by Gemini 3.1 Pro with Google Search integration.
 
 Capabilities:
 
@@ -1953,7 +1953,7 @@ If the IFD has an ADS-B receiver, AvareX also picks up its **Capstone** ADS-B tr
 
 - Current Pro AI workflows are targeted for iOS/Android only.
 - Access from map account icon → Pro Services → Flight Intelligence.
-- Uses Gemini 2.5 Pro with Google Search integration.
+- Uses Gemini 3.1 Pro with Google Search integration.
 - Source threads:
   - AI feature thread:  
     `https://groups.google.com/g/apps4av-forum/c/wWZUn6TNG1w`

--- a/lib/ai/ai_screen.dart
+++ b/lib/ai/ai_screen.dart
@@ -22,7 +22,12 @@ class AiScreen extends StatefulWidget {
 class AiScreenState extends State<AiScreen> {
 
   bool _clear = false;
-  final _model = FirebaseAI.vertexAI().generativeModel(model: 'gemini-2.5-pro', tools: [Tool.googleSearch()]);
+  // gemini-2.5-pro retires Oct 2026; gemini-3.1-pro-preview is the recommended
+  // Pro successor and requires the Vertex AI global endpoint.
+  final _model = FirebaseAI.vertexAI(location: 'global').generativeModel(
+    model: 'gemini-3.1-pro-preview',
+    tools: [Tool.googleSearch()],
+  );
   bool _isSending = false;
   final TextEditingController _editingController = TextEditingController();
 

--- a/lib/ai/ai_screen.dart
+++ b/lib/ai/ai_screen.dart
@@ -22,10 +22,11 @@ class AiScreen extends StatefulWidget {
 class AiScreenState extends State<AiScreen> {
 
   bool _clear = false;
-  // gemini-2.5-pro retires Oct 2026; gemini-3.1-pro-preview is the recommended
-  // Pro successor and requires the Vertex AI global endpoint.
-  final _model = FirebaseAI.vertexAI(location: 'global').generativeModel(
-    model: 'gemini-3.1-pro-preview',
+  // gemini-2.5-pro retires Oct 2026. Use stable Gemini 3.6 Flash (Vertex
+  // recommended migration path) rather than gemini-3.1-pro-preview, which
+  // previously failed on Vertex with "attachment is not supported".
+  final _model = FirebaseAI.vertexAI().generativeModel(
+    model: 'gemini-3.6-flash',
     tools: [Tool.googleSearch()],
   );
   bool _isSending = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gemini 2.5 Pro (`gemini-2.5-pro`) retires as early as October 16, 2026. This updates Flight Intelligence to a supported Gemini 3 model on Vertex AI.

## Changes

- Switch model from `gemini-2.5-pro` to stable `gemini-3.6-flash`
- Keep Google Search grounding enabled
- Update `USER_MANUAL.md` and regenerate `assets/docs/USER_MANUAL.pdf`

## Why not 3.1 Pro?

`gemini-3.1-pro-preview` is Google’s named Pro successor, but it previously failed on Vertex with **“attachment is not supported”**. Vertex’s documented replacement path for `gemini-2.5-pro` is the Gemini 3.x Flash line; `gemini-3.6-flash` is the current stable Flash model and supports Google Search grounding.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb07a-9cbe-7f0f-bf4d-155fc6944d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb07a-9cbe-7f0f-bf4d-155fc6944d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

